### PR TITLE
change nokogirl to nokogiri in Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,7 @@ source "https://rubygems.org"
 group :production do
   platforms :mri_19, :mri_20 do
     gem "algorithms"
-    gem "nokogirl"
+    gem "nokogiri"
     gem "cuba"
     gem "rake"
     gem "resque"


### PR DESCRIPTION
The gem name is misspelled (but still works) and it complains on a bundle install.

Don't worry, I have other contributions to make too. :)
