### PR TITLE
give nicer error message if local_settings.rb does not exist

### DIFF
--- a/tabula_web.rb
+++ b/tabula_web.rb
@@ -2,6 +2,8 @@
 require 'cuba'
 require 'cuba/render'
 
+raise Errno::ENOENT, "'./local_settings.rb' could not be found. See README.md for more info." unless File.exists?('./local_settings.rb')
+
 require 'nokogiri'
 require 'digest/sha1'
 require 'json'


### PR DESCRIPTION
I anticipate that failing to create local_settings.rb will be a pretty common user error when they're trying to bootstrap. I added a nicer error message to tabula_web.rb if local_settings.rb is missing.

Error message used to be: /Users/jmerrill/code/tabula/lib/jobs/generate_thumbails.rb:1:in `require_relative': cannot load such file -- /Users/jmerrill/code/tabula/local_settings.rb (LoadError)

Now: /Users/jmerrill/code/tabula/tabula_web.rb:5:in `<top (required)>': No such file or directory - './local_settings.rb' could not be found. See README.md for more info. (Errno::ENOENT)
