### PR TITLE
Hack ImgAreaSelect to move the boxes correctly when the directions heade...

### DIFF
--- a/static/js/pdf_view.js
+++ b/static/js/pdf_view.js
@@ -43,6 +43,10 @@ var rotatePath = function(path, rot_deg) {
 
 $(function () {
 
+    $('button.close#directions').click(function(){
+      $('div.ias').each(function(){ $(this).offset({top: $(this).offset()["top"] - $(directionsRow).height() }); });
+    })
+
     var PDF_ID = window.location.pathname.split('/')[2];
     lastQuery = {};
 

--- a/static/scripts/jquery.imgareaselect.js
+++ b/static/scripts/jquery.imgareaselect.js
@@ -18,8 +18,14 @@ var abs = Math.abs,
     min = Math.min,
     round = Math.round;
 
-function div() {
-    return $('<div/>');
+function div(cssClass) {
+    //optionally takes 
+    var mydiv = $('<div/>');
+    mydiv.addClass("ias"); 
+    if(cssClass){
+        mydiv.addClass(cssClass);
+    }
+    return mydiv
 }
 
 $.imgAreaSelect = function (img, options) {
@@ -29,10 +35,10 @@ $.imgAreaSelect = function (img, options) {
 
         imgLoaded,
 
-        $box = div(),
-        $area = div(),
-        $border = div().add(div()).add(div()).add(div()),
-        $outer = div().add(div()).add(div()).add(div()),
+        $box = div("ias-box"),
+        $area = div("ias-area"),
+        $border = div("ias-border").add(div("ias-border-1")).add(div("ias-border-2")).add(div("ias-border-3")),
+        $outer = div("ias-outer").add(div("ias-outer-1")).add(div("ias-outer-2")).add(div("ias-outer-3")),
         $handles = $([]),
 
         $areaOpera,

--- a/views/layout.erb
+++ b/views/layout.erb
@@ -28,7 +28,7 @@
     </div>
 
     <script type="text/javascript" src="/scripts/jquery.min.js"></script>
-    <script type="text/javascript" src="/scripts/jquery.imgareaselect.pack.js"></script>
+    <script type="text/javascript" src="/scripts/jquery.imgareaselect.js"></script>
     <script type="text/javascript" src="/js/jcanvas.min.js"></script>
     <script src="/js/bootstrap.min.js"></script>
     <script type="text/javascript">

--- a/views/pdf_view.html.erb
+++ b/views/pdf_view.html.erb
@@ -14,9 +14,9 @@
     </div> <!-- /sidebar container -->
     <div class="span10">
       <div class="alert alert-success" id="loading">Loading...</div>
-      <div class="row">
+      <div id="directionsRow" class="row">
         <div class="alert alert-info span7" >
-          <button type="button" class="close" data-dismiss="alert">×</button>
+          <button id="directions" type="button" class="close" data-dismiss="alert">×</button>
           <p><strong>How to use</strong>: make a rectangular selection over a table on the PDF pages. That's it!</p>
           <p><strong>Hint</strong>: table headers are (still) problematic. Try to exclude it from your selection.</p>
         </div>


### PR DESCRIPTION
...r is closed

Bug: If you click the X to close the directions header, the absolutely-positioned imgAreaSelects don't get moved, but the images, underneath, don't get moved. So, they're no longer lined up.

This commit adds classes for all of the imgAreaSelect elements, adds IDs to the directions header and adds JS to, when the directions header is closed, move the imgAreaSelect elements up by the amount of the height of the directions header. 

The imageAreaSelect js file still needs minifying and packing before we go live. (and switching the layout.erb to point to the packed version)
