### PR TITLE
Added instructions to tap homebrew/science for OpenCV

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,9 @@ a simple web interface:
     # Install numpy (feel free to put it in a virtualenv); opencv dependency
     pip install numpy
 
+    # Add the "science" tap to Homebrew so it can find OpenCV (if you haven't already)
+    brew tap homebrew/science
+
     brew install opencv --with-tbb --with-opencl --with-qt
     brew install mupdf redis
     ~~~


### PR DESCRIPTION
Homebrew removed OpenCV from its main repo on Sunday. This ensures you
still can install it.

Details: https://github.com/mxcl/homebrew/commit/9495b06ef3f35be8711902ce268
