### PR TITLE
use backbone in pdf_view.js

### DIFF
--- a/static/js/pdf_view.js
+++ b/static/js/pdf_view.js
@@ -1,5 +1,7 @@
 // TODO this really needs a refactor. maybe bootstrap.js
 
+Tabula = {};
+
 var clip = null;
 
 $(document).ready(function() {
@@ -10,331 +12,35 @@ $(document).ready(function() {
         client.setText($('table').table2CSV({delivery: null}));
         $('#myModal span').css('display', 'inline').delay(900).fadeOut('slow');
     });
-
 });
 
-var debugRulings;
-var debugColumns;
-var debugRows;
-var debugCharacters;
-var lastQuery;
-var lastSelection;
+Tabula.PDFView = Backbone.View.extend({
+    el : 'body',
+    events : {
+      'click button.close#directions' : 'moveSelectionsUp',
+      'click a.tooltip-modal': 'tooltip', //$('a.tooltip-modal').tooltip();
+      'change input#use_lines': 'toggleUseLines',
+      'hide #myModal' : function(){ clip.unglue('#copy-csv-to-clipboard'); },
+      'load .thumbnail-list li img': function() { $(this).after($('<div />', { class: 'selection-show'})); }
+    },
 
-var COLORS = ['#f00', '#0f0', '#00f', '#ffff00', '#FF00FF'];
+    moveSelectionsUp: function(){
+        $('div.ias').each(function(){ $(this).offset({top: $(this).offset()["top"] - $(directionsRow).height() }); });
+    },
 
-$(function () {
+    initialize: function(){
+      _.bindAll(this, 'render');
+      this.render();
+    },
 
-    $('button.close#directions').click(function(){
-      $('div.ias').each(function(){ $(this).offset({top: $(this).offset()["top"] - $(directionsRow).height() }); });
-    })
+    PDF_ID: window.location.pathname.split('/')[2],
+    colors: ['#f00', '#0f0', '#00f', '#ffff00', '#FF00FF'],
+    lastQuery: {},
 
-    var PDF_ID = window.location.pathname.split('/')[2];
-    lastQuery = {};
+    render : function(){
+      query_parameters = {};
 
-    debugWhitespace = function(image) {
-        image = $(image);
-        var imagePos = image.offset();
-        var newCanvas =  $('<canvas/>',{'class':'debug-canvas'})
-            .attr('width', image.width())
-            .attr('height', image.height())
-            .css('top', imagePos.top + 'px')
-            .css('left', imagePos.left + 'px');
-        $('body').append(newCanvas);
-
-        var thumb_width = $(image).width();
-        var thumb_height = $(image).height();
-        var pdf_width = parseInt($(image).data('original-width'));
-        var pdf_height = parseInt($(image).data('original-height'));
-        var pdf_rotation = parseInt($(image).data('rotation'));
-
-        // if rotated, swap width and height
-        if (pdf_rotation == 90 || pdf_rotation == 270) {
-            var tmp = pdf_height;
-            pdf_height = pdf_width;
-            pdf_width = tmp;
-        }
-
-        var scale = (thumb_width / pdf_width);
-
-        $.get('/debug/' + PDF_ID + '/whitespace',
-              lastQuery,
-              function(data) {
-                  // whitespace
-                  $.each(data, function(i, row) {
-                      $(newCanvas).drawRect({
-                          x: row.left * scale,
-                          y: row.top * scale,
-                          width: row.width * scale,
-                          height: row.height * scale,
-                          /*strokeStyle: '#f00', */fillStyle: '#f00',
-                          fromCenter: false
-                      });
-                  });
-              });
-    };
-
-    debugGraph = function(image) {
-    image = $(image);
-        var imagePos = image.offset();
-        var newCanvas =  $('<canvas/>',{'class':'debug-canvas'})
-            .attr('width', image.width())
-            .attr('height', image.height())
-            .css('top', imagePos.top + 'px')
-            .css('left', imagePos.left + 'px');
-        $('body').append(newCanvas);
-
-        var thumb_width = $(image).width();
-        var thumb_height = $(image).height();
-        var pdf_width = parseInt($(image).data('original-width'));
-        var pdf_height = parseInt($(image).data('original-height'));
-        var pdf_rotation = parseInt($(image).data('rotation'));
-
-        // if rotated, swap width and height
-        if (pdf_rotation == 90 || pdf_rotation == 270) {
-            var tmp = pdf_height;
-            pdf_height = pdf_width;
-            pdf_width = tmp;
-        }
-
-        var scale = (thumb_width / pdf_width);
-
-        $.get('/debug/' + PDF_ID + '/graph',
-              lastQuery,
-              function(data) {
-                  // draw rectangles enclosing each cluster
-                  $.each(data.vertices, function(i, row) {
-                      $(newCanvas).drawRect({
-                          x: lastSelection.x1,
-                          y: row.top * scale_y,
-                          width: lastSelection.x2 - lastSelection.x1,
-                          height: row.bottom - row.top,
-                          strokeStyle: COLORS[i % COLORS.length],
-                          fromCenter: false
-                      });
-                  });
-
-                  // draw lines connecting clusters (edges)
-                  // $.each(data, function(i, row) {
-                  //     $(newCanvas).drawRect({
-                  //         x: lastSelection.x1,
-                  //         y: row.top * scale_y,
-                  //         width: lastSelection.x2 - lastSelection.x1,
-                  //         height: row.bottom - row.top,
-                  //         strokeStyle: COLORS[i % COLORS.length],
-                  //         fromCenter: false
-                  //     });
-                  // });
-              });
-    };
-
-    debugRulings = function(image) {
-        image = $(image);
-        var imagePos = image.offset();
-        var newCanvas =  $('<canvas/>',{'class':'debug-canvas'})
-            .attr('width', image.width())
-            .attr('height', image.height())
-            .css('top', imagePos.top + 'px')
-            .css('left', imagePos.left + 'px');
-        $('body').append(newCanvas);
-        var pdf_width = parseInt($(image).data('original-width'));
-
-        var scaleFactor = image.width() / pdf_width ;
-
-        var lq = $.extend(lastQuery,
-                          {
-                              pdf_page_width: $('img#page-' + lastQuery.page).data('original-width')
-                          });
-
-        $.get('/debug/' + PDF_ID + '/rulings',
-              lq,
-              function(data) {
-                  $.each(data, function(i, ruling) {
-                      $("canvas").drawLine({
-                          strokeStyle: COLORS[i % COLORS.length],
-                          strokeWidth: 1,
-                          x1: ruling[0] * scaleFactor, y1: ruling[1] * scaleFactor,
-                          x2: ruling[2] * scaleFactor, y2: ruling[3] * scaleFactor
-                      });
-                  });
-              });
-    };
-
-
-    debugRows = function(image, use_rulings) {
-        image = $(image);
-        var imagePos = image.offset();
-        var newCanvas =  $('<canvas/>',{'class':'debug-canvas'})
-            .attr('width', image.width())
-            .attr('height', image.height())
-            .css('top', imagePos.top + 'px')
-            .css('left', imagePos.left + 'px');
-        $('body').append(newCanvas);
-
-        var thumb_width = $(image).width();
-        var thumb_height = $(image).height();
-        var pdf_width = parseInt($(image).data('original-width'));
-        var pdf_height = parseInt($(image).data('original-height'));
-        var pdf_rotation = parseInt($(image).data('rotation'));
-
-        // if rotated, swap width and height
-        if (pdf_rotation == 90 || pdf_rotation == 270) {
-            var tmp = pdf_height;
-            pdf_height = pdf_width;
-            pdf_width = tmp;
-        }
-
-        var scale = (thumb_width / pdf_width);
-
-        if (use_rulings !== undefined)
-            $.extend(lastQuery, { use_lines: true});
-
-        $.get('/debug/' + PDF_ID + '/rows',
-              lastQuery,
-              function(data) {
-                  $.each(data, function(i, row) {
-                      $(newCanvas).drawRect({
-                          x: lastSelection.x1,
-                          y: row.top * scale,
-                          width: lastSelection.x2 - lastSelection.x1,
-                          height: row.bottom - row.top,
-                          strokeStyle: COLORS[i % COLORS.length],
-                          fromCenter: false
-                      });
-                  });
-              });
-    };
-
-
-    debugColumns = function(image) {
-        image = $(image);
-        var imagePos = image.offset();
-        var newCanvas =  $('<canvas/>',{'class':'debug-canvas'})
-            .attr('width', image.width())
-            .attr('height', image.height())
-            .css('top', imagePos.top + 'px')
-            .css('left', imagePos.left + 'px');
-        $('body').append(newCanvas);
-
-        var thumb_width = $(image).width();
-        var thumb_height = $(image).height();
-        var pdf_width = parseInt($(image).data('original-width'));
-        var pdf_height = parseInt($(image).data('original-height'));
-        var pdf_rotation = parseInt($(image).data('rotation'));
-
-        // if rotated, swap width and height
-        if (pdf_rotation == 90 || pdf_rotation == 270) {
-            var tmp = pdf_height;
-            pdf_height = pdf_width;
-            pdf_width = tmp;
-        }
-
-        var scale_x = (thumb_width / pdf_width);
-        var scale_y = (thumb_height / pdf_height);
-
-        $.get('/debug/' + PDF_ID + '/columns',
-              lastQuery,
-              function(data) {
-                  $.each(data, function(i, column) {
-                      $(newCanvas).drawRect({
-                          x: column.left * scale_x,
-                          y: lastSelection.y1,
-                          width: (column.right - column.left) * scale_x,
-                          height: lastSelection.y2 - lastSelection.y1,
-                          strokeStyle: COLORS[i % COLORS.length],
-                          fromCenter: false
-                      });
-                  });
-              });
-    };
-
-    debugCharacters = function(image) {
-        image = $(image);
-        var imagePos = image.offset();
-        var newCanvas =  $('<canvas/>',{'class':'debug-canvas'})
-            .attr('width', image.width())
-            .attr('height', image.height())
-            .css('top', imagePos.top + 'px')
-            .css('left', imagePos.left + 'px');
-        $('body').append(newCanvas);
-
-        var thumb_width = $(image).width();
-        var thumb_height = $(image).height();
-        var pdf_width = parseInt($(image).data('original-width'));
-        var pdf_height = parseInt($(image).data('original-height'));
-        var pdf_rotation = parseInt($(image).data('rotation'));
-
-        // if rotated, swap width and height
-        if (pdf_rotation == 90 || pdf_rotation == 270) {
-            var tmp = pdf_height;
-            pdf_height = pdf_width;
-            pdf_width = tmp;
-        }
-
-        var scale_x = (thumb_width / pdf_width);
-        var scale_y = (thumb_height / pdf_height);
-
-        $.get('/debug/' + PDF_ID + '/characters',
-              lastQuery,
-              function(data) {
-                  $.each(data, function(i, row) {
-                      $("canvas").drawRect({
-                          strokeStyle: COLORS[i % COLORS.length],
-                          strokeWidth: 1,
-                          x: row.left * scale_x, y: row.top * scale_y,
-                          width: row.width * scale_x,
-                          height: row.height * scale_y,
-                          fromCenter: false
-                      });
-                  });
-              });
-    };
-
-
-    $('a.tooltip-modal').tooltip();
-
-    $('input#use_lines').change(function() {
-        $.extend(lastQuery, { use_lines: $(this).is(':checked') });
-        doQuery(PDF_ID, lastQuery);
-    });
-
-    $('.thumbnail-list li img').load(function() {
-        $(this).after($('<div />',
-                        { class: 'selection-show'}));
-    });
-
-    query_parameters = {};
-
-
-    $('#myModal').on('hide', function() {
-        clip.unglue('#copy-csv-to-clipboard');
-    });
-
-    var doQuery = function(pdf_id, query_parameters) {
-        $('#loading').css('left', ($(window).width() - 98) + 'px').css('visibility', 'visible');
-
-        lastQuery = query_parameters;
-
-        $.extend(lastQuery, { use_lines: $('#use_lines').is(':checked') });
-
-        $.get('/pdf/' + pdf_id + '/data',
-              query_parameters,
-              function(data) {
-                  var tableHTML = '<table contenteditable="true" class="table table-condensed table-bordered">';
-                  $.each(data, function(i, row) {
-                      tableHTML += '<tr><td>' + $.map(row, function(cell, j) { return cell.text; }).join('</td><td>') + '</td></tr>';
-                  });
-                  tableHTML += '</table>';
-
-                  $('.modal-body').html(tableHTML);
-                  $('#download-csv').attr('href', '/pdf/' + pdf_id + '/data?format=csv&' + $.param(query_parameters));
-                  $('#download-tsv').attr('href', '/pdf/' + pdf_id + '/data?format=tsv&' + $.param(query_parameters));
-                  $('#myModal').modal();
-                  clip.glue('#copy-csv-to-clipboard');
-                  $('#loading').css('visibility', 'hidden');
-              });
-    };
-
-    $('img.page-image').imgAreaSelect({
+      $('img.page-image').imgAreaSelect({
         handles: true,
         //minHeight: 50, minWidth: 100,
         onSelectStart: function(img, selection)  {
@@ -347,9 +53,8 @@ $(function () {
                 .css('left', selection.x1 * scale + 'px')
                 .css('width', ((selection.x2 - selection.x1) * scale) + 'px')
                 .css('height', ((selection.y2 - selection.y1) * scale) + 'px');
-
         },
-        onSelectEnd: function(img, selection) {
+        onSelectEnd: _.bind(function(img, selection) {
             if (selection.width == 0 && selection.height == 0) {
                 $('#thumb-' + $(img).attr('id') + ' .selection-show').css('display', 'none');
             }
@@ -385,8 +90,302 @@ $(function () {
                 y2: selection.y2 * scale,
                 page: $(img).data('page')
             };
+            this.doQuery(this.PDF_ID, query_parameters);
+        }, this)
+      });
+      return this;
+    },
 
-            doQuery(PDF_ID, query_parameters);
-        }});
+    toggleUseLines: function() {
+        $.extend(this.lastQuery, { use_lines: $('input#use_lines').is(':checked') });
+        this.doQuery(this.PDF_ID, this.lastQuery);
+    },
 
+    debugWhitespace: function(image) {
+        image = $(image);
+        var imagePos = image.offset();
+        var newCanvas =  $('<canvas/>',{'class':'debug-canvas'})
+            .attr('width', image.width())
+            .attr('height', image.height())
+            .css('top', imagePos.top + 'px')
+            .css('left', imagePos.left + 'px');
+        $('body').append(newCanvas);
+
+        var thumb_width = $(image).width();
+        var thumb_height = $(image).height();
+        var pdf_width = parseInt($(image).data('original-width'));
+        var pdf_height = parseInt($(image).data('original-height'));
+        var pdf_rotation = parseInt($(image).data('rotation'));
+
+        // if rotated, swap width and height
+        if (pdf_rotation == 90 || pdf_rotation == 270) {
+            var tmp = pdf_height;
+            pdf_height = pdf_width;
+            pdf_width = tmp;
+        }
+
+        var scale = (thumb_width / pdf_width);
+
+        $.get('/debug/' + this.PDF_ID + '/whitespace',
+              this.lastQuery,
+              function(data) {
+                  // whitespace
+                  $.each(data, function(i, row) {
+                      $(newCanvas).drawRect({
+                          x: row.left * scale,
+                          y: row.top * scale,
+                          width: row.width * scale,
+                          height: row.height * scale,
+                          /*strokeStyle: '#f00', */fillStyle: '#f00',
+                          fromCenter: false
+                      });
+                  });
+              });
+    },
+
+    debugGraph: function(image) {
+      image = $(image);
+        var imagePos = image.offset();
+        var newCanvas =  $('<canvas/>',{'class':'debug-canvas'})
+            .attr('width', image.width())
+            .attr('height', image.height())
+            .css('top', imagePos.top + 'px')
+            .css('left', imagePos.left + 'px');
+        $('body').append(newCanvas);
+
+        var thumb_width = $(image).width();
+        var thumb_height = $(image).height();
+        var pdf_width = parseInt($(image).data('original-width'));
+        var pdf_height = parseInt($(image).data('original-height'));
+        var pdf_rotation = parseInt($(image).data('rotation'));
+
+        // if rotated, swap width and height
+        if (pdf_rotation == 90 || pdf_rotation == 270) {
+            var tmp = pdf_height;
+            pdf_height = pdf_width;
+            pdf_width = tmp;
+        }
+
+        var scale = (thumb_width / pdf_width);
+
+        $.get('/debug/' + this.PDF_ID + '/graph',
+              this.lastQuery,
+              _.bind( function(data) {
+                  // draw rectangles enclosing each cluster
+                  $.each(data.vertices, _.bind(function(i, row) {
+                      $(newCanvas).drawRect({
+                          x: lastSelection.x1,
+                          y: row.top * scale_y,
+                          width: lastSelection.x2 - lastSelection.x1,
+                          height: row.bottom - row.top,
+                          strokeStyle: this.colors[i % this.colors.length],
+                          fromCenter: false
+                      });
+                  }, this));
+
+                  // draw lines connecting clusters (edges)
+                  // $.each(data, function(i, row) {
+                  //     $(newCanvas).drawRect({
+                  //         x: lastSelection.x1,
+                  //         y: row.top * scale_y,
+                  //         width: lastSelection.x2 - lastSelection.x1,
+                  //         height: row.bottom - row.top,
+                  //         strokeStyle: this.colors[i % this.colors.length],
+                  //         fromCenter: false
+                  //     });
+                  // });
+              }, this));
+    },
+
+    debugRulings: function(image) {
+        image = $(image);
+        var imagePos = image.offset();
+        var newCanvas =  $('<canvas/>',{'class':'debug-canvas'})
+            .attr('width', image.width())
+            .attr('height', image.height())
+            .css('top', imagePos.top + 'px')
+            .css('left', imagePos.left + 'px');
+        $('body').append(newCanvas);
+        var pdf_width = parseInt($(image).data('original-width'));
+
+        var scaleFactor = image.width() / pdf_width ;
+
+        var lq = $.extend(this.lastQuery,
+                          {
+                              pdf_page_width: $('img#page-' + this.lastQuery.page).data('original-width')
+                          });
+
+        $.get('/debug/' + this.PDF_ID + '/rulings',
+              lq,
+              _.bind(function(data) {
+                  $.each(data, _.bind(function(i, ruling) {
+                      $("canvas").drawLine({
+                          strokeStyle: this.colors[i % this.colors.length],
+                          strokeWidth: 1,
+                          x1: ruling[0] * scaleFactor, y1: ruling[1] * scaleFactor,
+                          x2: ruling[2] * scaleFactor, y2: ruling[3] * scaleFactor
+                      });
+                  }, this));
+              }, bind));
+    },
+
+
+    debugRows: function(image, use_rulings) {
+        image = $(image);
+        var imagePos = image.offset();
+        var newCanvas =  $('<canvas/>',{'class':'debug-canvas'})
+            .attr('width', image.width())
+            .attr('height', image.height())
+            .css('top', imagePos.top + 'px')
+            .css('left', imagePos.left + 'px');
+        $('body').append(newCanvas);
+
+        var thumb_width = $(image).width();
+        var thumb_height = $(image).height();
+        var pdf_width = parseInt($(image).data('original-width'));
+        var pdf_height = parseInt($(image).data('original-height'));
+        var pdf_rotation = parseInt($(image).data('rotation'));
+
+        // if rotated, swap width and height
+        if (pdf_rotation == 90 || pdf_rotation == 270) {
+            var tmp = pdf_height;
+            pdf_height = pdf_width;
+            pdf_width = tmp;
+        }
+
+        var scale = (thumb_width / pdf_width);
+
+        if (use_rulings !== undefined)
+            $.extend(this.lastQuery, { use_lines: true});
+
+        $.get('/debug/' + this.PDF_ID + '/rows',
+              this.lastQuery,
+              _.bind(function(data) {
+                  $.each(data, _.bind(function(i, row) {
+                      $(newCanvas).drawRect({
+                          x: lastSelection.x1,
+                          y: row.top * scale,
+                          width: lastSelection.x2 - lastSelection.x1,
+                          height: row.bottom - row.top,
+                          strokeStyle: this.colors[i % this.colors.length],
+                          fromCenter: false
+                      });
+                  }, this));
+              }, this));
+    },
+
+
+    debugColumns: function(image) {
+        image = $(image);
+        var imagePos = image.offset();
+        var newCanvas =  $('<canvas/>',{'class':'debug-canvas'})
+            .attr('width', image.width())
+            .attr('height', image.height())
+            .css('top', imagePos.top + 'px')
+            .css('left', imagePos.left + 'px');
+        $('body').append(newCanvas);
+
+        var thumb_width = $(image).width();
+        var thumb_height = $(image).height();
+        var pdf_width = parseInt($(image).data('original-width'));
+        var pdf_height = parseInt($(image).data('original-height'));
+        var pdf_rotation = parseInt($(image).data('rotation'));
+
+        // if rotated, swap width and height
+        if (pdf_rotation == 90 || pdf_rotation == 270) {
+            var tmp = pdf_height;
+            pdf_height = pdf_width;
+            pdf_width = tmp;
+        }
+
+        var scale_x = (thumb_width / pdf_width);
+        var scale_y = (thumb_height / pdf_height);
+
+        $.get('/debug/' + this.PDF_ID + '/columns',
+              this.lastQuery,
+              _.bind(function(data) {
+                  $.each(data, _.bind(function(i, column) {
+                      $(newCanvas).drawRect({
+                          x: column.left * scale_x,
+                          y: lastSelection.y1,
+                          width: (column.right - column.left) * scale_x,
+                          height: lastSelection.y2 - lastSelection.y1,
+                          strokeStyle: this.colors[i % this.colors.length],
+                          fromCenter: false
+                      });
+                  }, this));
+              }, this));
+    },
+
+    debugCharacters: function(image) {
+      image = $(image);
+      var imagePos = image.offset();
+      var newCanvas =  $('<canvas/>',{'class':'debug-canvas'})
+          .attr('width', image.width())
+          .attr('height', image.height())
+          .css('top', imagePos.top + 'px')
+          .css('left', imagePos.left + 'px');
+      $('body').append(newCanvas);
+
+      var thumb_width = $(image).width();
+      var thumb_height = $(image).height();
+      var pdf_width = parseInt($(image).data('original-width'));
+      var pdf_height = parseInt($(image).data('original-height'));
+      var pdf_rotation = parseInt($(image).data('rotation'));
+
+      // if rotated, swap width and height
+      if (pdf_rotation == 90 || pdf_rotation == 270) {
+          var tmp = pdf_height;
+          pdf_height = pdf_width;
+          pdf_width = tmp;
+      }
+
+      var scale_x = (thumb_width / pdf_width);
+      var scale_y = (thumb_height / pdf_height);
+
+      $.get('/debug/' + this.PDF_ID + '/characters',
+            this.lastQuery,
+            _.bind(function(data) {
+                $.each(data, _.bind(function(i, row) {
+                    $("canvas").drawRect({
+                        strokeStyle: this.colors[i % this.colors.length],
+                        strokeWidth: 1,
+                        x: row.left * scale_x, y: row.top * scale_y,
+                        width: row.width * scale_x,
+                        height: row.height * scale_y,
+                        fromCenter: false
+                    });
+                }, this));
+            }, this));
+    },
+
+
+    doQuery: function(pdf_id, query_parameters) {
+        $('#loading').css('left', ($(window).width() - 98) + 'px').css('visibility', 'visible');
+
+        this.lastQuery = query_parameters;
+
+        $.extend(this.lastQuery, { use_lines: $('#use_lines').is(':checked') });
+
+        $.get('/pdf/' + pdf_id + '/data',
+              query_parameters,
+              function(data) {
+                  var tableHTML = '<table contenteditable="true" class="table table-condensed table-bordered">';
+                  $.each(data, function(i, row) {
+                      tableHTML += '<tr><td>' + $.map(row, function(cell, j) { return cell.text; }).join('</td><td>') + '</td></tr>';
+                  });
+                  tableHTML += '</table>';
+
+                  $('.modal-body').html(tableHTML);
+                  $('#download-csv').attr('href', '/pdf/' + pdf_id + '/data?format=csv&' + $.param(query_parameters));
+                  $('#download-tsv').attr('href', '/pdf/' + pdf_id + '/data?format=tsv&' + $.param(query_parameters));
+                  $('#myModal').modal();
+                  clip.glue('#copy-csv-to-clipboard');
+                  $('#loading').css('visibility', 'hidden');
+              });
+    }
+});
+
+$(function () {
+  Tabula.pdf_view = new Tabula.PDFView();
 });

--- a/views/layout.erb
+++ b/views/layout.erb
@@ -35,6 +35,8 @@
 
     <script type="text/javascript" src="/scripts/jquery.min.js"></script>
     <script type="text/javascript" src="/scripts/jquery.imgareaselect.js"></script>
+    <script type="text/javascript" src="/scripts/underscore-min.js"></script>
+    <script type="text/javascript" src="/scripts/backbone-min.js"></script>
     <script type="text/javascript" src="/js/jcanvas.min.js"></script>
     <script src="/js/bootstrap.min.js"></script>
     <script type="text/javascript">


### PR DESCRIPTION
To resolve #2.

Everything behaves the same, but pdf_view.js is better formatted. That's not a huge change right now, but this will be super helpful once tabledetection is merged, which comes with lots of extra buttons, etc. 

We may want to refactor this even further to have one parent view for the whole interface and child views for each page of the PDF. Not sure if that would work, given how most of the things we want to implement are inter-page, like #12, applying the same lasso to multiple pages. 

I left the ZeroClipboard stuff out of Backbone, since it's weird (and small).

I can't get the debug methods to work on master, so I can't test if they work with my refactor. But those that I call don't error out, but nothing returns (or shows up, afaik).
