### PR TITLE
add closing tag to XML in jruby_dump_characters

### DIFF
--- a/lib/jruby_dump_characters.rb
+++ b/lib/jruby_dump_characters.rb
@@ -84,7 +84,7 @@ end
 <?xml version="1.0" encoding="UTF-8"?>
 <index>
 <% pages.each_with_index do |page, page_number| %>
-<page number="<%= page_number + 1 %>" top="0" left="0" height="<%= prec(page.findCropBox.getHeight) %>" width="<%= prec(page.findCropBox.getWidth) %>" rotation="<%= page.getRotation.to_i %>">
+<page number="<%= page_number + 1 %>" top="0" left="0" height="<%= prec(page.findCropBox.getHeight) %>" width="<%= prec(page.findCropBox.getWidth) %>" rotation="<%= page.getRotation.to_i %>" />
 <% end %>
 </index>
 EOT


### PR DESCRIPTION
Without the closing tag, Nokogiri interprets the unclosed <page> elements as nested, and then, if you have >256, it reaches Nokogiri's depth limit, and then you get errors.

With the closing tag, everything is happy.

This solves problem 1 in my big comment on #63 .
