### PR TITLE
draw arbitrary notifications matching on date, versions from gh-pages

### DIFF
--- a/webapp/static/js/file-library.js
+++ b/webapp/static/js/file-library.js
@@ -1,0 +1,13 @@
+$(function(){
+  $('#uploadedfiles li button').on('click', function() {
+     var a = $(this).prevUntil('a').prev();
+     if (!confirm('Delete file "'+a.html()+'"?')) return;
+     var pdf_id = a.attr('href').split('/')[2];
+     $.post('/pdf/' + pdf_id,
+            { _method: 'delete' },
+            function() {
+             $(a).parent().fadeOut(200,
+                                   function() { $(this).remove(); });
+         });
+  });
+});

--- a/webapp/static/js/update-notifications.js
+++ b/webapp/static/js/update-notifications.js
@@ -1,0 +1,84 @@
+$(function() {
+  console.log(TABULA_VERSION);
+
+  $.get('https://api.github.com/repos/jazzido/tabula/releases',
+       function(data) {
+         if (data.length < 1) return;
+         // check if new version
+         var i = data.map(function(d) { return d.name; }).indexOf(TABULA_VERSION);
+         // if index >= 1, current release is not the newest
+         if (i == 0) return;
+         var new_release = data[i-1];
+         if(new_release){
+           $('div#update-alert a').attr('href', new_release.html_url);
+           $('div#update-alert #new-version').html(new_release.name);
+           $('div#update-alert').css('display', 'block');
+         }
+     });
+  $.ajax({
+    url: 'http://jazzido.github.io/tabula/notifications.jsonp', 
+    dataType: "jsonp",
+    jsonpCallback: 'notifications',
+    success: function(data){
+      if(data.length < 1) return;
+
+      // find the first listed notification where today is between its `live_date` and `expires_date`
+      // and within the `versions` list.
+      // we might use this for, say, notifying users if a version urgently needs an update or something
+      // 
+      var notifications = $.grep(data, function(d){
+        var today = new Date();
+        if ( (d.expires_date && (new Date(d.expires_date) < today)) || (d.live_date && (new Date(d.live_date) > today)) ){ 
+          return false;
+        }
+        // var split_tabula_version = TABULA_VERSION.split(".")
+        // var tabula_major_version = split_tabula_version[0]
+        // var tabula_minor_version = split_tabula_version[1]
+        // var tabula_bugfix_version = split_tabula_version[2]
+
+        // if(d.start_version){
+        //   var split_start_version = d.start_version.split(".")
+        //   var start_major_version = split_start_version[0]
+        //   var start_minor_version = split_start_version[1]
+        //   var start_bugfix_version = split_start_version[2]
+        // }
+        // if(d.end_version){
+        //   var split_end_version = d.end_version.split(".")
+        //   var end_major_version = split_end_version[0]
+        //   var end_minor_version = split_end_version[1]
+        //   var end_bugfix_version = split_end_version[2]
+        // }
+
+        // if ((d.end_version && tabula_major_version > end_major_version) || (d.start_version && tabula_major_version < start_major_version) ){
+        //   console.log('failed on major')
+        //   return false;
+        // }
+        // if ((d.end_version && tabula_minor_version > end_minor_version) || (d.start_version && tabula_minor_version < start_minor_version) ){
+        //   console.log('failed on minor')
+        //   return false;
+        // }
+        // if ((d.end_version && tabula_bugfix_version > end_bugfix_version) || 
+        //     (d.start_version && tabula_bugfix_version < start_bugfix_version) ){
+        //   console.log('failed on bugfix')
+        //   return false;
+        // }
+        if( d.versions && d.versions.length > 0){
+          return (d.versions.indexOf(TABULA_VERSION) > -1);
+        }else{
+          return true;
+        }
+      });
+
+      if(notifications.length >= 1){
+        console.log(notifications.length + " matching notifications:", notifications);
+        var notification = notifications[0];
+        $('div#custom-alert strong').html(notification.name);
+        $('div#custom-alert span.custom-alert-body').html(notification.body);
+        $('div#custom-alert').css('display', 'block');
+      }else{
+        console.log("no notifications")
+      }
+
+  
+    }});
+});

--- a/webapp/views/index.html.erb
+++ b/webapp/views/index.html.erb
@@ -16,9 +16,14 @@
         <p>Liberate data tables trapped inside PDF files</p>
       </div> <!-- /hero-unit -->
 
-      <div class="alert alert-warning alert-dismissable" style="display: none;">
+      <div class="alert alert-warning alert-dismissable" id="update-alert" style="display: none;">
           <button type="button" class="close" data-dismiss="alert" aria-hidden="true">&times;</button>
           <strong>New version!</strong> <a href="">Tabula <span id="new-version">version</span></a> is available (you have <span id="installed-version"><%= $TABULA_VERSION %></span>)
+      </div>
+
+      <div class="alert alert-warning alert-dismissable" id="custom-alert" style="display: none;">
+          <button type="button" class="close" data-dismiss="alert" aria-hidden="true">&times;</button>
+          <strong>New version!</strong> <span class="custom-alert-body"></span>
       </div>
 
       <div id="demo">
@@ -53,38 +58,11 @@
           </div>
         </div>
       </div>
-
-      <script type="text/javascript">
-       $(function() {
-
-           var TABULA_VERSION = '<%= $TABULA_VERSION %>';
-
-           $('#uploadedfiles li button').on('click', function() {
-               var a = $(this).prevUntil('a').prev();
-               if (!confirm('Delete file "'+a.html()+'"?')) return;
-               var pdf_id = a.attr('href').split('/')[2];
-               $.post('/pdf/' + pdf_id,
-                      { _method: 'delete' },
-                      function() {
-                       $(a).parent().fadeOut(200,
-                                             function() { $(this).remove(); });
-                   });
-           });
-
-           $.get('https://api.github.com/repos/jazzido/tabula/releases',
-                 function(data) {
-                   if (data.length < 1) return;
-                   // check if new version
-                   var i = data.map(function(d) { return d.name; }).indexOf(TABULA_VERSION);
-                   // if index >= 1, current release is not the newest
-                   if (i == 0) return;
-                   var new_release = data[i-1];
-                   $('div.alert a').attr('href', new_release.html_url);
-                   $('div.alert #new-version').html(new_release.name);
-                   $('div.alert').css('display', 'block');
-               });
-       });
+      <script type="text/javascript"> 
+          var TABULA_VERSION = '<%= $TABULA_VERSION %>';
       </script>
+      <script type="text/javascript" src="/js/file-library.js"></script>
+      <script type="text/javascript" src="/js/update-notifications.js"></script>
 
       <br><br><hr>
       <p><strong>Tabula</strong> was created by <a href="http://jazzido.com/" target="_blank">Manuel Aristarán</a> with the help of <a href="http://propublica.org">ProPublica</a>, <a href="http://blogs.lanacion.com.ar/data/">La Nación DATA</a> and <a href="http://www.mozillaopennews.org/">Knight-Mozilla OpenNews</a></p>


### PR DESCRIPTION
Per email, this'll display a notification with an arbitrary title and body from our gh-pages site at http://jazzido.github.io/tabula/notifications.jsonp. We can target users to see these notifications via version number and a start date and an end date. 

Dunno how often we'll want to use this, but it's nice to have it -- perhaps asking users to take a survey or something.

I don't see if that updates checkbox is hooked up to anything. We should hook it up to a setting to turn off notifications so that, if the user doesn't want notifications, they'll never ping GitHub's servers -- or an analytics server we hypothetically set up to see how many people are using our software based on the ping from the notifications feeds.

I also, just for the sake of separation of concerns, moved both the notification JS code and the recent files deletion code out of `index.html.erb` and into their own .js files.
