### PR TITLE
Switch web framework from Cuba to Roda

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,7 @@
 
 source "https://rubygems.org"
 platform :jruby do
-  gem "cuba"
+  gem "roda"
   gem "rack"
   gem "tilt"
   gem "rufus-lru"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,12 +1,12 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    cuba (3.3.0)
-      rack
     jruby-jars (1.7.15)
     jruby-rack (1.1.16)
     rack (1.5.2)
     rake (10.3.2)
+    roda (1.3.0)
+      rack
     rubyzip (1.1.6)
     rufus-lru (1.0.5)
     tabula-extractor (0.7.6-java)
@@ -23,10 +23,10 @@ PLATFORMS
   java
 
 DEPENDENCIES
-  cuba
   jruby-jars (= 1.7.15)
   rack
   rake
+  roda
   rufus-lru
   tabula-extractor (~> 0.7.6)
   tilt

--- a/config.ru
+++ b/config.ru
@@ -1,7 +1,7 @@
 # encoding: UTF-8
 require_relative './webapp/tabula_settings.rb'
 require_relative './webapp/tabula_web.rb'
-run Cuba
+run Roda.app
 
 if "#{$PROGRAM_NAME}".include?("tabula.jar")
   # only do this if running as jar or app. (if "rackup", we don't
@@ -10,7 +10,7 @@ if "#{$PROGRAM_NAME}".include?("tabula.jar")
   require 'java'
 
   # don't do "java_import java.net.URI" -- it conflicts with Ruby URI and
-  # makes Cuba/Rack really really upset. just call "java.*" classes
+  # makes Roda/Rack really really upset. just call "java.*" classes
   # directly.
   port = java.lang.Integer.getInteger('jetty.port', 8080)
   url = "http://127.0.0.1:#{port}"

--- a/webapp/tabula_debug.rb
+++ b/webapp/tabula_debug.rb
@@ -1,108 +1,86 @@
 require 'json'
 
-class TabulaDebug < Cuba
-  define do
+class TabulaDebug < Roda
+  clear_middleware!
 
-    on ":file_id/characters" do |file_id|
-      par = JSON.load(req.params['coords']).first
+  route do
+    on :file_id, :method=>:get do |file_id|
+      par = JSON.load(request['coords']).first
       page = par['page']
-
       pdf_path = File.join(TabulaSettings::DOCUMENTS_BASEPATH, file_id, 'document.pdf')
       extractor = Tabula::Extraction::ObjectExtractor.new(pdf_path, [page])
 
-      text_elements = extractor.extract.next.get_text([par['y1'].to_f,
-                                                       par['x1'].to_f,
-                                                       par['y2'].to_f,
-                                                       par['x2'].to_f])
+      is "characters" do |file_id|
+        text_elements = extractor.extract.next.get_text([par['y1'].to_f,
+                                                         par['x1'].to_f,
+                                                         par['y2'].to_f,
+                                                         par['x2'].to_f])
 
-      res['Content-Type'] = 'application/json'
-      res.write text_elements.map { |te|
-        { 'left' => te.left,
-          'top' => te.top,
-          'width' => te.width,
-          'height' => te.height,
-          'text' => te.text }
-      }.to_json
-    end
-
-    on ":file_id/text_chunks" do |file_id|
-      par = JSON.load(req.params['coords']).first
-      page = par['page']
-
-      pdf_path = File.join(TabulaSettings::DOCUMENTS_BASEPATH, file_id, 'document.pdf')
-      extractor = Tabula::Extraction::ObjectExtractor.new(pdf_path, [page])
-
-      text_elements = extractor.extract.next.get_text([par['y1'].to_f,
-                                                       par['x1'].to_f,
-                                                       par['y2'].to_f,
-                                                       par['x2'].to_f])
-
-      text_chunks = Tabula::TextElement.merge_words(text_elements)
-
-      puts text_chunks.inspect
-
-      res['Content-Type'] = 'application/json'
-      res.write text_chunks.map { |te|
-        { 'left' => te.left,
-          'top' => te.top,
-          'width' => te.width,
-          'height' => te.height,
-          'text' => te.text }
-      }.to_json
-    end
-
-
-    on ":file_id/clipping_paths" do |file_id|
-      par = JSON.load(req.params['coords']).first
-      page = par['page']
-
-      pdf_path = File.join(TabulaSettings::DOCUMENTS_BASEPATH, file_id, 'document.pdf')
-      extractor = Tabula::Extraction::ObjectExtractor.new(pdf_path, [page])
-      extractor.debug_clipping_paths = true
-
-      extractor.extract.next
-
-      res['Content-Type'] = 'application/json'
-      res.write extractor.clipping_paths.map { |cp|
-        {
-          'left' => cp.left,
-          'top' => cp.top,
-          'width' => cp.width,
-          'height' => cp.height
+        text_elements.map { |te|
+          { 'left' => te.left,
+            'top' => te.top,
+            'width' => te.width,
+            'height' => te.height,
+            'text' => te.text }
         }
-      }.to_json
-    end
-
-    on ":file_id/rulings" do |file_id|
-      par = JSON.load(req.params['coords']).first
-      page = par['page']
-
-      pdf_path = File.join(TabulaSettings::DOCUMENTS_BASEPATH, file_id, 'document.pdf')
-      extractor = Tabula::Extraction::ObjectExtractor.new(pdf_path, [page])
-
-      # crop lines to area of interest
-      par = JSON.load(req.params['coords']).first
-      top, left, bottom, right = [par['y1'].to_f,
-                                  par['x1'].to_f,
-                                  par['y2'].to_f,
-                                  par['x2'].to_f]
-
-      area = Tabula::ZoneEntity.new(top, left,
-                                    right - left, bottom - top)
-
-      page_obj = extractor.extract.next
-      page_area = page_obj.get_area(area)
-      rulings = page_area.ruling_lines
-
-      intersections = {}
-      if req.params['show_intersections'] != 'false'
-        intersections = Tabula::Ruling.find_intersections(page_area.horizontal_ruling_lines,
-                                                          page_area.vertical_ruling_lines)
       end
 
-      res['Content-Type'] = 'application/json'
-      res.write({:rulings => rulings.uniq, :intersections => intersections.keys }.to_json)
-    end
+      is "text_chunks" do |file_id|
+        text_elements = extractor.extract.next.get_text([par['y1'].to_f,
+                                                         par['x1'].to_f,
+                                                         par['y2'].to_f,
+                                                         par['x2'].to_f])
 
+        text_chunks = Tabula::TextElement.merge_words(text_elements)
+
+        text_chunks.map { |te|
+          { 'left' => te.left,
+            'top' => te.top,
+            'width' => te.width,
+            'height' => te.height,
+            'text' => te.text }
+        }
+      end
+
+
+      is "clipping_paths" do |file_id|
+        extractor.debug_clipping_paths = true
+
+        extractor.extract.next
+
+        extractor.clipping_paths.map { |cp|
+          {
+            'left' => cp.left,
+            'top' => cp.top,
+            'width' => cp.width,
+            'height' => cp.height
+          }
+        }
+      end
+
+      is "rulings" do |file_id|
+        # crop lines to area of interest
+        top, left, bottom, right = [par['y1'].to_f,
+                                    par['x1'].to_f,
+                                    par['y2'].to_f,
+                                    par['x2'].to_f]
+
+        area = Tabula::ZoneEntity.new(top, left,
+                                      right - left, bottom - top)
+
+        page_obj = extractor.extract.next
+        page_area = page_obj.get_area(area)
+        rulings = page_area.ruling_lines
+
+        intersections = {}
+        if request['show_intersections'] != 'false'
+          intersections = Tabula::Ruling.find_intersections(page_area.horizontal_ruling_lines,
+                                                            page_area.vertical_ruling_lines)
+        end
+
+        {:rulings => rulings.uniq, :intersections => intersections.keys}
+      end
+
+    end
   end
 end

--- a/webapp/tabula_job_progress.rb
+++ b/webapp/tabula_job_progress.rb
@@ -1,52 +1,51 @@
 require_relative '../lib/tabula_job_executor/executor.rb'
 
-class TabulaJobProgress < Cuba
-  define do
-    on ":upload_id/json" do |batch_id|
+class TabulaJobProgress < Roda
+  clear_middleware!
+
+  route do
+    on :upload_id, :method=>:get do |batch_id|
       # upload_id is the "job id" uuid that resque-status provides
       batch = Tabula::Background::JobExecutor.get_by_batch(batch_id)
-      res['Content-Type'] = 'application/json'
-      message = {}
-      if batch.empty?
-        res.status = 404
-        message[:status] = "error"
-        message[:message] = "No such job"
-        message[:pct_complete] = 0
-      elsif batch.any? { |uuid, job| job.failed? }
-        message[:status] = "error"
-        message[:message] = "Sorry, your file upload could not be processed. Please double-check that the file you uploaded is a valid PDF file and try again."
-        message[:pct_complete] = 99
-        res.write message.to_json
-      else
-        s = batch.find { |uuid, job| job.working? }
-        message[:status] = !s.nil? ? s.last.status['status'] : 'completed'
-        message[:message] = !s.nil? && !s.last.message.nil? ? s.last.message.first : ''
-        message[:pct_complete] = (batch.inject(0.0) { |sum, (uuid, job)| sum + job.pct_complete } / batch.size).to_i
-        message[:file_id] = req.params['file_id']
-        message[:upload_id] = batch_id
-        res.write message.to_json
+
+      is "json" do |batch_id|
+        message = {}
+        if batch.empty?
+          response.status = 404
+          message[:status] = "error"
+          message[:message] = "No such job"
+          message[:pct_complete] = 0
+        elsif batch.any? { |uuid, job| job.failed? }
+          message[:status] = "error"
+          message[:message] = "Sorry, your file upload could not be processed. Please double-check that the file you uploaded is a valid PDF file and try again."
+          message[:pct_complete] = 99
+        else
+          s = batch.find { |uuid, job| job.working? }
+          message[:status] = !s.nil? ? s.last.status['status'] : 'completed'
+          message[:message] = !s.nil? && !s.last.message.nil? ? s.last.message.first : ''
+          message[:pct_complete] = (batch.inject(0.0) { |sum, (uuid, job)| sum + job.pct_complete } / batch.size).to_i
+          message[:file_id] = request['file_id']
+          message[:upload_id] = batch_id
+        end
+        message
       end
-    end
 
-    on ":upload_id" do |batch_id|
-      # upload_id is the "job id" uuid that resque-status provides
-      batch = Tabula::Background::JobExecutor.get_by_batch(batch_id)
-
-      if batch.empty?
-        res.status = 404
-        res.write ""
-        res.write view("upload_error.html",
-                       :message => "invalid upload_id (TODO: make this generic 404)")
-      elsif batch.any? { |uuid, job| job.failed? }
-        res.write view("upload_error.html",
-                       :message => "Sorry, your file upload could not be processed. Please double-check that the file you uploaded is a valid PDF file and try again.")
-      else
-        s = batch.find { |uuid, job| job.working? }
-        res.write view("upload_status.html",
-                       :status => !s.nil? ? s.last.message : 'completed',
-                       :pct_complete => (batch.inject(0.0) { |sum, (uuid, job)| sum + job.pct_complete } / batch.size).to_i,
-                       :upload_id => batch_id,
-                       :file_id => req.params['file_id'])
+      is do
+        if batch.empty?
+          response.status = 404
+          view("upload_error.html", :locals=>{
+               :message => "invalid upload_id (TODO: make this generic 404)"})
+        elsif batch.any? { |uuid, job| job.failed? }
+          view("upload_error.html", :locals=>{
+               :message => "Sorry, your file upload could not be processed. Please double-check that the file you uploaded is a valid PDF file and try again."})
+        else
+          s = batch.find { |uuid, job| job.working? }
+          view("upload_status.html", :locals=>{
+               :status => !s.nil? ? s.last.message : 'completed',
+               :pct_complete => (batch.inject(0.0) { |sum, (uuid, job)| sum + job.pct_complete } / batch.size).to_i,
+               :upload_id => batch_id,
+               :file_id => request['file_id']})
+        end
       end
     end
   end

--- a/webapp/views/layout.erb
+++ b/webapp/views/layout.erb
@@ -12,7 +12,7 @@
     <% if $TABULA_VERSION.start_with?('rev') %>
         <div class="ribbon-wrapper-green"><div class="ribbon-green">DEV mode</div></div>
     <% end %>
-    <% if req.path != "/" %>
+    <% if request.path != "/" %>
     <div class="navbar navbar-inverse navbar-fixed-top">
       <div class="navbar-inner">
         <div class="container-fluid">
@@ -51,6 +51,6 @@
     </script>
 
     <br>    <br>    <br>
-    <%= content %>
+    <%= yield %>
   </body>
 </html>


### PR DESCRIPTION
Roda is a fork of Cuba.  Here are the advantages I see to this change:

1) Uses terminal routes.  One of the reasons behind the fork is that
by default, routes in Cuba are not terminal.  So the following
requests are currently handled the same by Tabula:

POST /upload
POST /upload/with/additional/stuff

Basically, you can stick whatever you want at the end of a path, and
Cuba will just ignore it.  Roda has built in support for terminal
routes, so adding stuff at the end of the path will result in a
404, like practically all websites.

2) Comes with a JSON plugin.  This simplifies JSON handling, and makes
it so you don't have to set the Content-Type to application/json and
call .to_json manually.  You just have the route block return an array
or hash, and Roda will automatically convert it to json for you.

While I was converting the app from Cuba to Roda, I noticed there were
some parts that could derive more benefit from the routing tree.  One
example is TabulaDebug, where I moved a some duplicate code in every
route up to the enclosing branch, so the behavior is shared by all of
the routes under the branch.

Some things get a little more verbose with the switch, such as the
second argument to Roda#view is a general options hash instead of
specific to local variables.  In general that could be made simpler by
passing data to the views implicitly using instance variables instead
of local variables.

Some other changes:

1) require 'tilt/erb' explicitly.  This avoids some warnings printed
by tilt, which should be the case for both Roda and Cuba.

2) require tabula_debug and tabula_job_progress outside of the
routing tree, so they aren't required on every request that uses them.

Disclaimer: I'm the author of Roda.