### PR TITLE
Treat 'basic' extraction as a non-spreadsheet extraction method

### DIFF
--- a/lib/tabula_java_wrapper.rb
+++ b/lib/tabula_java_wrapper.rb
@@ -44,7 +44,7 @@ module Tabula
     Enumerator.new do |y|
       extractor.extract(pages.map { |p| p.to_java(:int) }).each do |page|
         specs[page.getPageNumber].each do |spec|
-          if ["spreadsheet", "original"].include?(spec['extraction_method'])
+          if ["spreadsheet", "original", "basic"].include?(spec['extraction_method'])
             use_spreadsheet_extraction_method = spec['extraction_method'] == "spreadsheet"
           else
             use_spreadsheet_extraction_method = sea.isTabular(page)


### PR DESCRIPTION
On the export page, if you choose "original" as the extraction method, the server responds with an extraction method of "basic" which gets set as the extraction value in the export form. However, "basic" gets treated as a "guess" on a subsequent export, so if you have a file where the guess doesn't return any tables you're out of luck.

With this change the server recognizes "basic" as a non-spreadsheet extraction method.
