### PR TITLE
Add background job warnings & warn about auto-detect failures

### DIFF
--- a/lib/tabula_job_executor/executor.rb
+++ b/lib/tabula_job_executor/executor.rb
@@ -117,6 +117,10 @@ module Tabula
         self.status.merge!({ 'status' => 'queued', 'queued_on' => Time.now })
       end
 
+      def warn(*warnings)
+        self.status.merge!({ 'warnings' => warnings })
+      end
+
       def failed(*messages)
         self.status.merge!({ 'status' => 'failed', 'messages' => messages})
       end
@@ -140,6 +144,12 @@ module Tabula
       end
 
       alias_method :message?, :message
+
+      def warning
+        self.status['warnings']
+      end
+
+      alias_method :warning?, :warning
 
       STATUSES = %w{queued working completed failed killed}.freeze
       STATUSES.each do |status|

--- a/webapp/index.html
+++ b/webapp/index.html
@@ -212,6 +212,11 @@
       <script type='text/template' id='file-upload-template'>
         <h5><%= filename %></h5>
         <span id="message"><%= message %></span>
+        <ul class="list-unstyled">
+          <% for(var warning in warnings) { %>
+              <li class="text-danger">Warning: <%= warnings[warning] %></li>
+          <% } %>
+        </ul>
         <div class="progress">
           <div class="progress-bar" role="progressbar" aria-valuenow="60" aria-valuemin="0" aria-valuemax="100" style="width: <%= pct_complete %>%;"><span class="sr-only"> <%= pct_complete %>% Complete </span></div>
         </div>

--- a/webapp/static/js/library.js
+++ b/webapp/static/js/library.js
@@ -8,6 +8,7 @@ Tabula.FileUpload = Backbone.Model.extend({
     this.set({
       message: 'waiting to be processed...',
       pct_complete: 0,
+      warnings: []
     });
   },
 
@@ -27,6 +28,7 @@ Tabula.FileUpload = Backbone.Model.extend({
             }
 
             this.set('pct_complete', data.pct_complete);
+            this.set('warnings', data.warnings);
 
             if (data.status == "error" && data.error_type == "unknown") {
                 // window.location.reload(true);


### PR DESCRIPTION
I noticed that when the table auto-detect job failed, it would stop users from trying to manually select tables from the document, even though having that job fail doesn't necessarily mean tables can't be extracted from the file.

I added warnings to background jobs, and changed the auto-detect job so that if an exception is thrown in tabula-java then the job completes with a warning instead of a general failure.

I also modified the web app to display warnings returned by the file upload process.