### PR TITLE
Specifying versions of gems in Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,14 +5,14 @@
 source "https://rubygems.org"
 platform :jruby do
   gem "cuba"
-  gem "rack"
-  gem "tilt"
+  gem "rack", "~> 1.6.0"
+  gem "tilt", "~> 1.4.0"
 
   group :development do
     gem "rake"
     gem "warbler", "~> 1.4.9"
     gem "jruby-jars", "1.7.22" ##1.7.16.1 doesn't work, see issue #203
+    gem "bootstrap-sass", "~> 3.2.0"
     gem "compass"
-    gem "bootstrap-sass"
   end
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,13 +1,9 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    autoprefixer-rails (5.1.11)
-      execjs
-      json
-    bootstrap-sass (3.3.4.1)
-      autoprefixer-rails (>= 5.0.0.1)
-      sass (>= 3.2.19)
-    chunky_png (1.3.4)
+    bootstrap-sass (3.2.0.2)
+      sass (~> 3.2)
+    chunky_png (1.3.5)
     compass (1.0.3)
       chunky_png (~> 1.2)
       compass-core (~> 1.0.2)
@@ -20,22 +16,20 @@ GEM
       sass (>= 3.3.0, < 3.5)
     compass-import-once (1.0.5)
       sass (>= 3.2, < 3.5)
-    cuba (3.4.0)
-      rack
-    execjs (2.5.2)
-    ffi (1.9.8-java)
+    cuba (3.5.0)
+      rack (~> 1.6.0)
+    ffi (1.9.10-java)
     jruby-jars (1.7.22)
-    jruby-rack (1.1.19)
-    json (1.8.2-java)
-    multi_json (1.11.0)
-    rack (1.6.0)
-    rake (10.4.2)
-    rb-fsevent (0.9.4)
+    jruby-rack (1.1.20)
+    multi_json (1.11.2)
+    rack (1.6.4)
+    rake (10.5.0)
+    rb-fsevent (0.9.7)
     rb-inotify (0.9.5)
       ffi (>= 0.5.0)
     rubyzip (1.1.7)
-    sass (3.4.13)
-    tilt (2.0.1)
+    sass (3.4.21)
+    tilt (1.4.1)
     warbler (1.4.9)
       jruby-jars (>= 1.5.6, < 2.0)
       jruby-rack (>= 1.1.1, < 1.3)
@@ -46,14 +40,14 @@ PLATFORMS
   java
 
 DEPENDENCIES
-  bootstrap-sass
+  bootstrap-sass (~> 3.2.0)
   compass
   cuba
   jruby-jars (= 1.7.22)
-  rack
+  rack (~> 1.6.0)
   rake
-  tilt
+  tilt (~> 1.4.0)
   warbler (~> 1.4.9)
 
 BUNDLED WITH
-   1.10.6
+   1.11.2


### PR DESCRIPTION
Also update the Gemfile.lock to avoid mistakes upon packaging (war).

These changes avoid errors about Rack gem on Linux while loading tabula (closes issue #457)