### PR TITLE
Catch web browser launching failure

### DIFF
--- a/config.ru
+++ b/config.ru
@@ -43,12 +43,20 @@ if "#{$PROGRAM_NAME}".include?("tabula.jar")
   if have_desktop
     puts "\n======================================================"
     puts "Launching web browser to #{url}\n\n"
-    puts "If it does not open in 10 seconds, you may manually open"
-    puts "a web browser to the above URL."
+
+    begin
+      desktop.browse(uri)
+    rescue
+      puts "Unable to launch your web browser, you will have to"
+      puts "manually open it to the above URL."
+    else
+      puts "If it does not open in 10 seconds, you may manually open"
+      puts "a web browser to the above URL."
+    end
+
     puts "When you're done using the Tabula interface, you may"
     puts "return to this window and press \"Control-C\" to close it."
     puts "======================================================\n\n"
-    desktop.browse(uri)
   else
     puts "\n======================================================"
     puts "Server now listening at: #{url}\n\n"


### PR DESCRIPTION
Running some unusual window manager may result in the Web browser launching failure. Here is the output when using [Qtile](http://www.qtile.org):

```
[...]
======================================================
Launching web browser to http://127.0.0.1:8080

If it does not open in 10 seconds, you may manually open
a web browser to the above URL.
When you're done using the Tabula interface, you may
return to this window and press "Control-C" to close it.
======================================================

ERROR: initialization failed
org.jruby.rack.RackInitializationException: java.lang.UnsupportedOperationException: The BROWSE action is not supported on the current platform!
[...]
```

I then got an *Internal Server Error* when trying to access the above URL with the same error message. Here is the console output:

```
DEBUG: due a previous initialization failure application instance can not be returned
DEBUG: resetting rack response due exception
```

So, this pull request only catches this error to be able to access your great application even if *browse* is not supported!