### PR TITLE
make Tabula work under a relative path

### DIFF
--- a/config.ru
+++ b/config.ru
@@ -4,7 +4,21 @@ require 'bundler'
 Bundler.require
 require_relative './webapp/tabula_settings.rb'
 require_relative './webapp/tabula_web.rb'
-run Cuba
+
+potential_root_uri_without_slashes = (defined?($servlet_context) ? $servlet_context.getContextPath : ENV["ROOT_URI"])
+
+if potential_root_uri_without_slashes.nil? || potential_root_uri_without_slashes == ''
+  ROOT_URI = '/'
+else
+  ROOT_URI = (potential_root_uri_without_slashes[0] == "/" ? '' : '/') + potential_root_uri_without_slashes +  (potential_root_uri_without_slashes[-1] == "/" ? '' : '/')
+end
+
+puts "running under #{ROOT_URI} as root URI" 
+
+
+map ROOT_URI do 
+  run Cuba
+end
 
 if "#{$PROGRAM_NAME}".include?("tabula.jar")
   # only do this if running as jar or app. (if "rackup", we don't

--- a/webapp/index.html
+++ b/webapp/index.html
@@ -7,15 +7,17 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta name="description" content="">
     <meta name="author" content="">
-    <link rel="shortcut icon" href="/img/favicon.ico" type="image/x-icon">
-    <link rel="icon" href="/img/favicon.ico" type="image/x-icon">
+    <link rel="shortcut icon" href="img/favicon.ico" type="image/x-icon">
+    <link rel="icon" href="img/favicon.ico" type="image/x-icon">
 
     <title>Tabula</title>
 
-    <link href="/css/styles.css" rel="stylesheet">
+    <base href="/"><!-- overwritten dynamically with the value of $servlet_context.getContextPath or ENV["ROOT_URI"] -->
+
+    <link href="css/styles.css" rel="stylesheet">
 
     <!-- Selector-specific CSS -->
-    <link href="/css/selectors.css" rel="stylesheet">
+    <link href="css/selectors.css" rel="stylesheet">
 
     <!-- HTML5 shim and Respond.js for IE8 support of HTML5 elements and media queries -->
     <!--[if lt IE 9]>
@@ -23,10 +25,10 @@
       <script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>
     <![endif]-->
 
-    <script type="text/javascript" src="/js/vendor/jquery.min.js"></script>
-    <script type="text/javascript" src="/js/vendor/underscore-min.js"></script>
-    <script type="text/javascript" src="/js/vendor/backbone-min.js"></script>
-    <script type="text/javascript" src="/js/vendor/bootstrap.js"></script>
+    <script type="text/javascript" src="js/vendor/jquery.min.js"></script>
+    <script type="text/javascript" src="js/vendor/underscore-min.js"></script>
+    <script type="text/javascript" src="js/vendor/backbone-min.js"></script>
+    <script type="text/javascript" src="js/vendor/bootstrap.js"></script>
   </head>
 
 
@@ -37,13 +39,13 @@
     <nav class="navbar navbar-default navbar-fixed-top" role="navigation">
       <div class="container">
         <div class="navbar-header">
-          <a class="navbar-brand" href="/">Tabula</a>
+          <a class="navbar-brand" href="">Tabula</a>
         </div>
         <div id="navbar" class="navbar-collapse collapse">
           <ul class="nav navbar-nav">
-            <li><a id="upload-nav" href="/">My Files</a></li>
-            <li><a id="about-nav" href="/about">About</a></li>
-            <li><a id="help-nav" href="/help">Help</a></li>
+            <li><a id="upload-nav" href="">My Files</a></li>
+            <li><a id="about-nav" href="about">About</a></li>
+            <li><a id="help-nav" href="help">Help</a></li>
             <li><a href="https://github.com/tabulapdf/tabula">Source Code</a></li>
           </ul>
         </div><!--/.nav-collapse -->
@@ -77,7 +79,7 @@
       </script>
 
       <script type="text/template" id="export-control-panel-template">
-        <form id="download-form" action="/pdf/<%=pdf_id%>/data?format=csv" method="post">
+        <form id="download-form" action="pdf/<%=pdf_id%>/data?format=csv" method="post">
           <div id="hidden-fields">
             <input type='hidden' class='data-query' name='new_filename' value='<%=original_filename%>' >
             <input type='hidden' class='data-query' name='coords' value='<%=list_of_coords%>' >
@@ -95,7 +97,7 @@
             <!-- <option value="xml">XML</option> -->
             <option value="script">Script</option>
           </select>
-          <button type="submit" <%=disableIfNoData%> id="download-data" class="btn btn-default" data-action='/pdf/<%=pdf_id%>/data'>
+          <button type="submit" <%=disableIfNoData%> id="download-data" class="btn btn-default" data-action='pdf/<%=pdf_id%>/data'>
             <span class="glyphicon glyphicon-refresh"></span>
             <span class="glyphicon glyphicon-download"></span>
             Export
@@ -191,11 +193,11 @@
           <div id="pages-container">
           </div>
         </div>
-        <nestedscript type="text/javascript" src="/js/vendor/spin.min.js"></nestedscript>
-        <nestedscript type="text/javascript" src="/js/resizableSelection.js"></nestedscript>
-        <nestedscript type="text/javascript" src="/js/rectangularSelector.js"></nestedscript>
-        <nestedscript type="text/javascript" src="/js/vendor/ZeroClipboard.min.js"></nestedscript>
-        <!-- <nestedscript type="text/javascript" src="/js/debug_pdf_view.js"></nestedscript>  -->
+        <nestedscript type="text/javascript" src="js/vendor/spin.min.js"></nestedscript>
+        <nestedscript type="text/javascript" src="js/resizableSelection.js"></nestedscript>
+        <nestedscript type="text/javascript" src="js/rectangularSelector.js"></nestedscript>
+        <nestedscript type="text/javascript" src="js/vendor/ZeroClipboard.min.js"></nestedscript>
+        <!-- <nestedscript type="text/javascript" src="js/debug_pdf_view.js"></nestedscript>  -->
       </script>
 
 
@@ -302,9 +304,9 @@
         </div> <!-- /container -->
 
         <!-- we are using this here: http://www.abeautifulsite.net/whipping-file-inputs-into-shape-with-bootstrap-3/ -->
-        <nestedscript type="text/javascript" src="/js/vendor/upload-group.js"></nestedscript>
-        <nestedscript type="text/javascript" src="/js/vendor/jquery.tablesorter.min.js"></nestedscript>
-        <nestedscript type="text/javascript" src="/js/vendor/spin.min.js"></nestedscript>
+        <nestedscript type="text/javascript" src="js/vendor/upload-group.js"></nestedscript>
+        <nestedscript type="text/javascript" src="js/vendor/jquery.tablesorter.min.js"></nestedscript>
+        <nestedscript type="text/javascript" src="js/vendor/spin.min.js"></nestedscript>
       </script>
 
       <script type="text/template" id="uploaded-file-template">
@@ -313,7 +315,7 @@
         <td><%= page_count || '??' %></td>
         <td><%= new Date(parseInt(time) * 1000).toUTCString().slice(5, -7) %></td>
         <td><a href="javascript:"><span data-filename=<%= original_filename %> data-pdfid=<%= id %> class="glyphicon glyphicon-remove delete-pdf"></span></a></td>
-        <td><a href="/pdf/<%= id %>"><button type="button" class="btn btn-sm btn-success">Extract Data</button></a></td>
+        <td><a href="pdf/<%= id %>"><button type="button" class="btn btn-sm btn-success">Extract Data</button></a></td>
       </script>
 
       <script type="text/template" id="upload-error-template" >
@@ -374,7 +376,7 @@
           <li><strong>Some columns of my table are combined. What can I do?</strong> Tabula sometimes uses "streams" of whitespace to recreate your table's structure. If headers span multiple columns, they're probably causing a problem. Try excluding them from your selection (or selecting them separately). </li>
           <li><strong>Some columns of my table are combined. And the headers aren't the problem! What <em>else</em> can I do?</strong> Tabula has two extraction methods. It tries to guess which one is right for document, but it's wrong sometimes. Try selecting the other (of "stream" and "lattice"), on the left in extraction mode, to see if that fixes the problem.</li>
           <li><strong>Tabula's taking too long!</strong> Sorry! Tabula has to do a lot of weird math to reconstruct your table. Tabula's command-line counterpart, <a href="https://www.github.com/tabulapdf/tabula-extractor">tabula-extractor</a> is faster, but a little harder to use. You might give it a try.</li>
-          <li><strong>I had some other problem!</strong> Sorry! You can <a href="https://www.github.com/tabulapdf/tabula/issues/new">report it to us here</a>. Be sure to include your PDF, either as a link or attached to the issue -- or email it to <a href="/about">one of the Tabula creators.</a> </li>
+          <li><strong>I had some other problem!</strong> Sorry! You can <a href="https://www.github.com/tabulapdf/tabula/issues/new">report it to us here</a>. Be sure to include your PDF, either as a link or attached to the issue -- or email it to <a href="about">one of the Tabula creators.</a> </li>
           </ol>
 
           </div> <!-- /jumbotron -->
@@ -393,7 +395,7 @@
 
     </script> <!-- TODO: move this to tabula.js, only run it if we're in upload page viewer -->
 
-    <script type="text/javascript" src="/js/tabula.js?_cachebuster=201510300905"></script> <!-- actually starts Tabula -->
+    <script type="text/javascript" src="js/tabula.js?_cachebuster=201510300905"></script> <!-- actually starts Tabula -->
 
   </body>
 </html>

--- a/webapp/static/js/library.js
+++ b/webapp/static/js/library.js
@@ -77,7 +77,7 @@ Tabula.UploadedFile = Backbone.Model.extend({
 
 Tabula.UploadedFilesCollection = Backbone.Collection.extend({
     model: Tabula.UploadedFile,
-    url: function(){ return '/pdfs/workspace.json'+ '?' + Number(new Date()).toString() },
+    url: function(){ return 'pdfs/workspace.json'+ '?' + Number(new Date()).toString() },
     comparator: function(i){ return -i.get('time')},
     parse: function(items){
       _(items).each(function(i){

--- a/webapp/static/js/pdf_view.js
+++ b/webapp/static/js/pdf_view.js
@@ -1,12 +1,13 @@
 Tabula = Tabula || {};
 
 var clip = null;
+var base_uri = $('base').attr("href");
 
-PDF_ID = window.location.pathname.split('/')[2];
+PDF_ID = window.location.pathname.replace(base_uri, '').split('/')[1];
 Tabula.LazyLoad = 10; // max number of pages around the cursor to show (2x Tabula.LazyLoad pages are shown)
 Tabula.HideOnLazyLoad = false; // ideally, set to true, but this requires differently positioned selections, see https://github.com/tabulapdf/tabula/issues/245#issuecomment-75182061
 
-ZeroClipboard.config( { swfPath: "/swf/ZeroClipboard.swf" } );
+ZeroClipboard.config( { swfPath: (base_uri || '/') + "swf/ZeroClipboard.swf" } );
 
 Tabula.Page = Backbone.Model.extend({
   // number: null, //set on initialize
@@ -18,7 +19,7 @@ Tabula.Page = Backbone.Model.extend({
   },
   imageUrl: function(){
     var resolution = Math.max(Tabula.pdf_view.pdf_document.get('thumbnail_sizes')) || 560;
-    this.set('image_url', '/pdfs/' + PDF_ID + '/document_'+resolution+'_' + this.get('number') + '.png');
+    this.set('image_url', (base_uri || '/') + 'pdfs/' + PDF_ID + '/document_'+resolution+'_' + this.get('number') + '.png');
     return this.get('image_url');
   }
 });
@@ -28,7 +29,7 @@ Tabula.Pages = Backbone.Collection.extend({
   url: null, //set on initialize
   comparator: 'number',
   initialize: function(){
-    this.url = '/pdfs/' + PDF_ID + '/pages.json?_=' + Math.round(+new Date()).toString();
+    this.url = (base_uri || '/') + 'pdfs/' + PDF_ID + '/pages.json?_=' + Math.round(+new Date()).toString();
   }
 });
 
@@ -42,7 +43,7 @@ Tabula.Document = Backbone.Model.extend({
     this.page_collection = new Tabula.Pages([], {pdf_document: this});
     this.selections = new Tabula.Selections([], {pdf_document: this});
     this.autodetected_selections = new Tabula.AutodetectedSelections([], {pdf_document: this});
-    this.url = '/pdf/' + this.pdf_id + '/metadata.json';
+    this.url = (base_uri || '/') + 'pdf/' + this.pdf_id + '/metadata.json';
 
     this.set('original_filename', '');
     this.set('new_filename', false);
@@ -171,7 +172,7 @@ Tabula.Selections = Backbone.Collection.extend({
 Tabula.AutodetectedSelections = Tabula.Selections.extend({
   url: null, //set on init
   initialize: function(){
-    this.url = '/pdfs/' + PDF_ID + '/tables.json?_=' + Math.round(+new Date()).toString();
+    this.url = (base_uri || '/') + 'pdfs/' + PDF_ID + '/tables.json?_=' + Math.round(+new Date()).toString();
     _.bindAll(this, 'updateOrCreateByVendorSelectorId');
   },
 
@@ -288,7 +289,7 @@ Tabula.Query = Backbone.Model.extend({
     window.tabula_router.navigate('pdf/' + PDF_ID + '/extract'); // TODO: this should probably go in a view!! -JBM
     $.ajax({
         type: 'POST',
-        url: '/pdf/' + PDF_ID + '/data',
+        url: (base_uri || '/') + 'pdf/' + PDF_ID + '/data',
         data: this.query_data,
         success: _.bind(function(resp) {
           this.set('data', resp);
@@ -1188,7 +1189,7 @@ Tabula.PDFView = Backbone.View.extend(
     },
 
     removePage: function(removedPageModel){
-      $.post('/pdf/' + PDF_ID + '/page/' + removedPageModel.get('number'),
+      $.post((base_uri || '/') + 'pdf/' + PDF_ID + '/page/' + removedPageModel.get('number'),
            { _method: 'delete' },
            function () {
                Tabula.pdf_view.pageCount -= 1;

--- a/webapp/static/js/tabula.js
+++ b/webapp/static/js/tabula.js
@@ -1,6 +1,7 @@
 var Tabula;
 window.Tabula = Tabula || {};
 $.ajaxSetup({ cache: false }); // fixes a dumb issue where Internet Explorer caches Ajax requests. See https://github.com/tabulapdf/tabula/issues/408
+var base_uri = $('base').attr("href");
 
 Tabula.UI_VERSION = "1.1.0-2016-09-21" // when we make releases, we should remember to up this.
 // Add '-pre' to the end of this for a prerelease version; this will let
@@ -9,6 +10,7 @@ Tabula.UI_VERSION = "1.1.0-2016-09-21" // when we make releases, we should remem
 // Note that this is separate from the "API version" (internal app version)
 // which is what we check against GitHub. In the future, this will allow us
 // to modularize the UI from the backend some more.
+
 
 var TabulaRouter = Backbone.Router.extend({
   routes: {
@@ -41,7 +43,7 @@ var TabulaRouter = Backbone.Router.extend({
     document.title="Import | Tabula";
     $('nav li a').removeClass('active'); $('nav #upload-nav').addClass('active');
     $.ajax({
-      url: "/js/library.js",
+      url: (base_uri || '/') + "js/library.js",
       dataType: "script",
       async: true,
       success: function(data, status, jqxhr){
@@ -60,7 +62,7 @@ var TabulaRouter = Backbone.Router.extend({
     $('#tabula-app').html( _.template( $('#pdf-view-template').html().replace(/nestedscript/g, 'script') )({}) );
 
     $.ajax({
-      url: "/js/pdf_view.js",
+      url: (base_uri || '/') + "js/pdf_view.js",
       dataType: "script",
       async: true,
       success: function(data, status, jqxhr){
@@ -78,7 +80,7 @@ var TabulaRouter = Backbone.Router.extend({
 Tabula.getVersion = function(){
   Tabula.notification = new Backbone.Model({});
   Tabula.new_version = new Backbone.Model({});
-  $.getJSON("/version", function(data){
+  $.getJSON((base_uri || '/') + "version", function(data){
     Tabula.api_version = data["api"];
     Tabula.getNotifications();
 
@@ -169,5 +171,8 @@ Tabula.getNotifications = function(){
 $(function(){
   Tabula.getVersion();
   window.tabula_router = new TabulaRouter();
-  Backbone.history.start({pushState: true});
+  Backbone.history.start({
+    pushState: true,
+    root: base_uri
+  });
 });

--- a/webapp/tabula_web.rb
+++ b/webapp/tabula_web.rb
@@ -93,7 +93,6 @@ def upload(file)
 end
 
 Cuba.define do
-
   if TabulaSettings::ENABLE_DEBUG_METHODS
     require_relative './tabula_debug.rb'
     on 'debug' do
@@ -168,7 +167,11 @@ Cuba.define do
 
     [root, "about", "pdf/:file_id", "help"].each do |paths_to_single_page_app|
       on paths_to_single_page_app do
-        res.write File.read("webapp/index.html")
+        index = File.read("webapp/index.html")
+        if ROOT_URI != ''
+          index.sub!("<base href=\"/\">", "<base href=\"#{ROOT_URI}\">")
+        end
+        res.write index
       end
     end
 


### PR DESCRIPTION
@jazzido and @theta682: Check out this branch and see if it works for you, in the situation you envision for running Tabula under a subpath.

`ROOT_URI=tabula bundle exec rackup` should serve a working version of Tabula under `localhost:9292/tabula/`.

I wasn't able to figure out how to set a context path, because my familiarity with Jetty, Tomcat, etc. is basically nothing. So that may not work, but it should be an easy fix at the top of config.ru

will close #110 and #547