### PR TITLE
rearranges control panel; adds button to repeat selections once

### DIFF
--- a/webapp/index.html
+++ b/webapp/index.html
@@ -111,20 +111,24 @@
       </script>
 
       <script type="text/template" id="select-control-panel-template" >
-        <a href="javascript:void(0)"><button type="button" id="clear-all-selections" class="btn btn-default" <%= disable_clear_all_selections %>><span class="glyphicon glyphicon-remove-circle"></span> Clear All Selections</button></a>
+        <span class="filename"><%= original_filename %></span>
         <div class="dropdown" <%= disable_load_template %> style="display: inline;">
-          <button type="button" class="dropdown-toggle btn btn-link" data-toggle="dropdown" href="#" <%= disabled_if_there_are_selections %>><span class="glyphicon glyphicon-import" title="You may only load a template if there are no selections active in your PDF."></span>Load Template</button>
+          <button type="button" class="dropdown-toggle btn btn-info" data-toggle="dropdown" href="#" ><span class="glyphicon glyphicon-import" title="You may only load a template if there are no selections active in your PDF."></span>Templates</button>
           <div id="template-dropdown-container" class="dropdown-menu">
             <ul>
               <li>
-                <button id="restore-detected-tables" type="button" class="btn btn-link <%= restore_detected_tables %>" <%= disabled_if_there_are_selections %>><span class="glyphicon glyphicon-flash"></span><span class="glyphicon glyphicon-refresh"></span> Autodetect Tables</button>
+                <a href="javascript:void(0)"><button type="button" id="save-template" class="btn btn-link" style="min-width: 155px;" <%= disable_save_template %>> <span class="button-text">Save Selections as Template</span> <span class="glyphicon glyphicon-export"></span></button></a>
               </li>
             </ul>
+            <p style="margin-left:5px;">Load templates:</p>
             <div id="template-dropdown-templates-list-container">
             </div>
           </div>
         </div>
-        <a href="javascript:void(0)"><button type="button" id="save-template" class="btn btn-info" style="min-width: 155px;" <%= disable_save_template %>><span class="glyphicon glyphicon-export"></span> <span class="button-text">Save as Template</span></button></a>
+
+
+        <a href="javascript:void(0)"><button type="button" id="clear-all-selections" class="btn btn-default" <%= disable_clear_all_selections %>><span class="glyphicon glyphicon-remove-circle"></span> Clear All Selections</button></a>
+        <button id="restore-detected-tables" type="button" class="btn btn-default <%= restore_detected_tables %>" <%= disabled_if_there_are_selections %>><span class="glyphicon glyphicon-flash"></span><span class="glyphicon glyphicon-refresh"></span> Autodetect Tables</button>
 
 
 
@@ -139,7 +143,6 @@
       </script>
 
       <script type="text/template" id="select-sidebar-template">
-        <span class="filename"><%= original_filename %></span>
         <ul id="thumbnail-list" class="thumbnail-list">
         </ul>
       </script>

--- a/webapp/index.html
+++ b/webapp/index.html
@@ -111,23 +111,37 @@
       </script>
 
       <script type="text/template" id="select-control-panel-template" >
-        <span class="filename"><%= original_filename %></span>
-
-        <a href="javascript:void(0)"><button id="restore-detected-tables" type="button" class="btn btn-default <%= restore_detected_tables %>" <%= disabled_if_there_are_selections %>><span class="glyphicon glyphicon-flash"></span><span class="glyphicon glyphicon-refresh"></span> Autodetect Tables</button></a>
         <a href="javascript:void(0)"><button type="button" id="clear-all-selections" class="btn btn-default" <%= disable_clear_all_selections %>><span class="glyphicon glyphicon-remove-circle"></span> Clear All Selections</button></a>
-        <a href="javascript:void(0)"><button type="button" id="all-data" class="btn btn-success" <%= disable_download_all %>><span class="glyphicon glyphicon-eye-open"></span> Preview & Export Extracted Data</button></a>
-
-        <span style="float: right;" class="template-menu">
-
-          <div class="dropdown" <%= disable_load_template %> style="display: inline;">
-            <button type="button" class="dropdown-toggle btn btn-link" data-toggle="dropdown" href="#" <%= disabled_if_there_are_selections %>><span class="glyphicon glyphicon-import" title="You may only load a template if there are no selections active in your PDF."></span>Load Template</button>
-            <div id="template-dropdown-container" class="dropdown-menu">
+        <div class="dropdown" <%= disable_load_template %> style="display: inline;">
+          <button type="button" class="dropdown-toggle btn btn-link" data-toggle="dropdown" href="#" <%= disabled_if_there_are_selections %>><span class="glyphicon glyphicon-import" title="You may only load a template if there are no selections active in your PDF."></span>Load Template</button>
+          <div id="template-dropdown-container" class="dropdown-menu">
+            <ul>
+              <li>
+                <button id="restore-detected-tables" type="button" class="btn btn-link <%= restore_detected_tables %>" <%= disabled_if_there_are_selections %>><span class="glyphicon glyphicon-flash"></span><span class="glyphicon glyphicon-refresh"></span> Autodetect Tables</button>
+              </li>
+            </ul>
+            <div id="template-dropdown-templates-list-container">
             </div>
           </div>
-          <a href="javascript:void(0)"><button type="button" id="save-template" class="btn btn-info" style="min-width: 155px;" <%= disable_save_template %>><span class="glyphicon glyphicon-export"></span> <span class="button-text">Save as Template</span></button></a>
+        </div>
+        <a href="javascript:void(0)"><button type="button" id="save-template" class="btn btn-info" style="min-width: 155px;" <%= disable_save_template %>><span class="glyphicon glyphicon-export"></span> <span class="button-text">Save as Template</span></button></a>
 
+
+
+        <span style="float: right">
+          <a href="javascript:void(0)"><button type="button" id="all-data" class="btn btn-success" <%= disable_download_all %>><span class="glyphicon glyphicon-list-alt"></span> Preview & Export Extracted Data</button></a>
         </span>
+
+
+
+
         <span style="clear: both;">
+      </script>
+
+      <script type="text/template" id="select-sidebar-template">
+        <span class="filename"><%= original_filename %></span>
+        <ul id="thumbnail-list" class="thumbnail-list">
+        </ul>
       </script>
 
       <script type="text/template" id="export-page-sidebar-template">

--- a/webapp/static/css/selectors.css
+++ b/webapp/static/css/selectors.css
@@ -8,7 +8,7 @@
 /* selections */
 .repeat-lassos-group {
   position: absolute;
-  right: -165px;
+  right: -185px;
   bottom: -35px;
 }
 

--- a/webapp/static/css/selectors.css
+++ b/webapp/static/css/selectors.css
@@ -6,7 +6,7 @@
 }
 
 /* selections */
-.repeat-lassos.btn {
+.repeat-lassos-group {
   position: absolute;
   right: -165px;
   bottom: -35px;

--- a/webapp/static/css/styles.css
+++ b/webapp/static/css/styles.css
@@ -7129,7 +7129,7 @@ button.close {
 /* selections */
 .repeat-lassos-group {
   position: absolute;
-  right: -165px;
+  right: -185px;
   bottom: -35px;
 }
 

--- a/webapp/static/css/styles.css
+++ b/webapp/static/css/styles.css
@@ -7127,7 +7127,7 @@ button.close {
 }
 
 /* selections */
-.repeat-lassos.btn {
+.repeat-lassos-group {
   position: absolute;
   right: -165px;
   bottom: -35px;
@@ -7514,12 +7514,22 @@ form {
 #control-panel span.filename {
   vertical-align: middle;
 }
-#control-panel .template-menu #template-dropdown-container ul {
+#control-panel #template-dropdown-container ul {
   padding-left: 20px;
 }
-#control-panel .template-menu #template-dropdown-container li {
+#control-panel #template-dropdown-container button {
+  padding-left: 0px;
+}
+#control-panel #template-dropdown-container ul:first-of-type {
+  margin-bottom: 0px;
+}
+#control-panel #template-dropdown-container li a {
   cursor: pointer;
-  text-decoration: underline;
+  color: #333;
+}
+#control-panel #template-dropdown-templates-list-container li a {
+  cursor: pointer;
+  color: #333;
 }
 
 #main-pane {

--- a/webapp/static/js/pdf_view.js
+++ b/webapp/static/js/pdf_view.js
@@ -1424,10 +1424,17 @@ Tabula.SavedTemplateView = Backbone.View.extend({
   render: function(){
     this.$el.append(this.template(this.model.attributes));
     this.$el.addClass('file-id-' + this.model.get('id')); // more efficient lookups than data-attr
+    if(Tabula.pdf_view.totalSelections() > 0){
+      this.$el.find("a").attr("disabled", "disabled");
+      this.$el.find("a").css({"color": "gray", "cursor": "default"})
+    }
     this.$el.data('id', this.model.get('id')); //more cleanly accesse than a class
     return this;
   },
-  loadTemplate: function(){
+  loadTemplate: function(e){
+    if($(e.currentTarget).attr("disabled")){
+      return;
+    }
     Tabula.pdf_view.loadSavedTemplate(this.model); // TODO: make this not a reference to global Tabula.pdf_view
   }
 });

--- a/webapp/static/sass/selectors.scss
+++ b/webapp/static/sass/selectors.scss
@@ -8,7 +8,7 @@
   /* selections */
 .repeat-lassos-group {
   position: absolute;
-  right: -165px;
+  right: -185px;
   bottom: -35px;
 }
 

--- a/webapp/static/sass/selectors.scss
+++ b/webapp/static/sass/selectors.scss
@@ -6,7 +6,7 @@
 }
 
   /* selections */
-.repeat-lassos.btn {
+.repeat-lassos-group {
   position: absolute;
   right: -165px;
   bottom: -35px;

--- a/webapp/static/sass/styles.scss
+++ b/webapp/static/sass/styles.scss
@@ -268,14 +268,24 @@ form {
 		vertical-align: middle;
 	}
 
-	.template-menu #template-dropdown-container{
+  #template-dropdown-container{
 		ul {
 			padding-left: 20px;
 		}
-		li {
-			cursor: pointer;
-			text-decoration: underline;
+		button { // this is the autodetected tables button
+			padding-left: 0px;
 		}
+		ul:first-of-type {
+			margin-bottom: 0px; // we're trying to make the template library <ul> and the <ul> that contains only the autodetected tables one look as if they're one <ul>
+		}
+		li a{
+			cursor: pointer;
+			color: #333;
+		}
+	}
+	#template-dropdown-templates-list-container li a {
+		cursor: pointer;
+		color: #333;
 	}
 }
 


### PR DESCRIPTION
1. adds option to repeat lasso only once, which'll close #715
2. rearranges the top of the selection page so there are fewer buttons (per @Jazzido's note on some other PR)

Because I'm bad at git and bad at debugging, these two changes are in one commit. 

This commit changes the conceptual category of "autodetect tables"; it's now under the Load Template menu. What do y'all think about this?

The reason for that change was to have fewer buttons on the top bar, so it works better on small screens. I also moved the filename from teh control panel to the sidebar (above the thumbnails).