### PR TITLE
Remove usage of unitialized variable data_home

### DIFF
--- a/webapp/tabula_settings.rb
+++ b/webapp/tabula_settings.rb
@@ -46,7 +46,7 @@ module TabulaSettings
       home = java.lang.System.getenv('XDG_DATA_HOME')
       if !home.nil?
         # XDG
-        data_dir = File.join(data_home, '/tabula')
+        data_dir = File.join(home, '/tabula')
       else
         # other, normal *NIX systems
         home = java.lang.System.getProperty('user.home')


### PR DESCRIPTION
I am trying to fix the exception I got when trying to run tabula on a Linux system with `XDG_DATA_HOME` defined:

```
An exception happened during JRuby-Rack startup
undefined local variable or method `data_home' for TabulaSettings:Module
--- System
jruby 9.1.5.0 (2.3.1) 2016-09-07 036ce39 OpenJDK 64-Bit Server VM 25.141-b15 on 1.8.0_141-8u141-b15-1~deb9u1-b15 +jit [linux-x86_64]
Time: 2017-10-16 08:21:32 +0200
Server: jetty/9.2.9.v20150224
jruby.home: uri:classloader://META-INF/jruby.home

--- Context Init Parameters:
jruby.compat.version = 1.9
jruby.rack.logging = stderr
public.root = /
rack.env = production

--- Backtrace
NameError: undefined local variable or method `data_home' for TabulaSettings:Module
                 getDataDir at /tmp/jetty-0.0.0.0-8080-tabula.jar-_-any-4772712634758927489.dir/webapp/WEB-INF/webapp/tabula_settings.rb:49
    <module:TabulaSettings> at /tmp/jetty-0.0.0.0-8080-tabula.jar-_-any-4772712634758927489.dir/webapp/WEB-INF/webapp/tabula_settings.rb:79
                     <main> at /tmp/jetty-0.0.0.0-8080-tabula.jar-_-any-4772712634758927489.dir/webapp/WEB-INF/webapp/tabula_settings.rb:4
                    require at org/jruby/RubyKernel.java:956
                     (root) at uri:classloader:/jruby/kernel/kernel.rb:1
  block in require_relative at uri:classloader:/jruby/kernel/kernel.rb:13
              instance_eval at org/jruby/RubyBasicObject.java:1667
                     (root) at /tmp/jetty-0.0.0.0-8080-tabula.jar-_-any-4772712634758927489.dir/webapp/WEB-INF/config.ru:5
                     <main> at /tmp/jetty-0.0.0.0-8080-tabula.jar-_-any-4772712634758927489.dir/webapp/WEB-INF/gems/gems/rack-1.6.4/lib/rack/builder.rb:55
[...]
```
