### PR TITLE
Fixed a bug causing duplicate object IDs

### DIFF
--- a/webapp/static/js/pdf_view.js
+++ b/webapp/static/js/pdf_view.js
@@ -181,7 +181,7 @@ Tabula.Selections = Backbone.Collection.extend({
   createHiddenSelection: function(sel){
       new_selection_args = _.extend({'page_number': sel.page,
                                     'extraction_method': 'spreadsheet',
-                                    'id': String.fromCharCode(65 + Math.floor(Math.random() * 26)) + Date.now(),
+                                    'id': Math.random().toString(),
                                     'hidden': true,
                                     'pdf_document': this.pdf_document},
                                     sel);


### PR DESCRIPTION
The ID values for new "Selection" objects were being generated by the line "String.fromCharCode(65 + Math.floor(Math.random() * 26)) + Date.now()", which led to the Auto-detection feature frequently skipping pages in large documents. The unique IDs are now simply generated by converting Math.random() to a string.