### PR TITLE
adds context bar to let users opt-out of notifications/stats

### DIFF
--- a/webapp/index.html
+++ b/webapp/index.html
@@ -487,7 +487,14 @@
           </div> <!-- /jumbotron -->
         </div> <!-- /container -->
        </script>
-
+       <script type="text/template" id="notifications-approval-template">
+          <div id="notifications-approval-clicky">
+            Tabula can check for new versions and notifications from the developers and tell you about them. We count these requests to get a rough estimate of how many times Tabula is used per day (instead of Google Analytics). We never receive any information about what PDFs you extract with Tabula.
+            <input type="button" id="notifications-approval-okay" value="Okay! Notify me and count me." />
+            <input type="button" id="notifications-approval-opt-out" value="No thanks" />
+            <a id="notifications-approval-close" >✕</a>
+          </div>
+       </script>
 
     </div> <!-- /templates -->
 

--- a/webapp/static/css/styles.css
+++ b/webapp/static/css/styles.css
@@ -7539,6 +7539,20 @@ form {
   color: #333;
 }
 
+#notifications-approval-clicky{
+  width: 100%;
+  padding: 1em 3em;
+  position: fixed;
+  bottom: 0;
+  background: #FFFFE0;
+  font-size: 14px;
+}
+#notifications-approval-clicky #notifications-approval-close {
+  position: absolute;
+  right: 0;
+  top: 0;
+}
+
 #main-pane {
   background: #777777;
   padding: 4.25em 2em 2em 2em;

--- a/webapp/static/js/tabula.js
+++ b/webapp/static/js/tabula.js
@@ -93,20 +93,58 @@ var TabulaRouter = Backbone.Router.extend({
 
 
 Tabula.getSettings = function(){
+
   Tabula.notification = new Backbone.Model({});
   Tabula.new_version = new Backbone.Model({});
   $.getJSON((base_uri || '/') + "settings", function(data){
-    Tabula.api_version = data["api_version"];
-    if(data["disable_version_check"] === false) {
-      Tabula.getLatestReleaseVersion();
-    }
-    if(data["disable_notifications"] === false) {
-      Tabula.getNotifications();
+
+    // there are two ways to turn off notifications: 
+    // 1. in settings.rb (which is set via command-line options) and in which you can turn off one
+    //    but not the other.
+    // 2. in localStorage.
+
+    // on first usage, we do nothing. once you've seen the opt-out banner,
+    // we continue to show it, but fetch notifications.
+
+    getNotifications = function(){
+      if(data["disable_version_check"] === false) {
+        Tabula.getLatestReleaseVersion();
+      }
+      if(data["disable_notifications"] === false) {
+        Tabula.getNotifications();
+      }
     }
 
-    // if(Tabula.api_version.slice(0,3) == "rev"){
-    //   $('#dev-mode-ribbon').show();
-    // }
+    var notificationsDialogSeen = localStorage.getItem("tabula-notifications-dialog-seen");
+    var acceptsNotifications = localStorage.getItem("tabula-notifications");
+    if (acceptsNotifications == "true"){
+      getNotifications();
+    }else if (acceptsNotifications == "false"){
+     // do nothing.
+    }else{ // null or unset
+      if (notificationsDialogSeen){
+        getNotifications();
+      }else{
+        localStorage.setItem("tabula-notifications-dialog-seen", true);
+      }
+      $('#tabula-app').after( _.template( $('#notifications-approval-template').html().replace(/nestedscript/g, 'script') )({ }) );
+      $('#notifications-approval-clicky #notifications-approval-close, #notifications-approval-clicky #notifications-approval-okay').on("click", function(){
+        localStorage.setItem("tabula-notifications-dialog-seen", true);
+        localStorage.setItem("tabula-notifications", true);
+        $('#notifications-approval-clicky').hide();
+      })
+      $('#notifications-approval-clicky #notifications-approval-opt-out').on("click", function(){
+        localStorage.setItem("tabula-notifications-dialog-seen", true);
+        localStorage.setItem("tabula-notifications", false);
+        $('#notifications-approval-clicky').hide();
+      })
+    }
+    Tabula.api_version = data["api_version"];
+    if(Tabula.api_version.slice(0,3) == "rev"){
+      // $('#dev-mode-ribbon').show();
+      console.log("This is a development version of Tabula!")
+    }
+
   })
 }
 
@@ -169,7 +207,6 @@ Tabula.getNotifications = function(){
       // find the first listed notification where today is between its `live_date` and `expires_date`
       // and within the `versions` list.
       // we might use this for, say, notifying users if a version urgently needs an update or something
-      //
       var notifications = $.grep(data, function(d){
         var today = new Date();
         if ( (d.expires_date && (new Date(d.expires_date) < today)) || (d.live_date && (new Date(d.live_date) > today)) ){
@@ -190,6 +227,7 @@ Tabula.getNotifications = function(){
       }
     }});
 }
+
 
 
 $(function(){


### PR DESCRIPTION
A little context bar at first use that asks if you want to opt-out of notifications/stats. Will resolve the concern raised in #923, #924. (There used to be a modal asking about this, but it got removed in a merge a few years back and, I, at least, didn't notice.)

This is a simple enough change, so it doesn't need "review" per se, but if one of you guys (@mtigas @jazzido )  has thoughts before I merge it, lemme know.

