### PR TITLE
Update .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 sudo: false
 language: ruby
+dist: trusty
 before_install:
   - gem update --system
   - gem install bundler


### PR DESCRIPTION
travis build is failing, see https://travis-ci.community/t/error-installing-oraclejdk8-expected-feature-release-number-in-range-of-9-to-14-but-got-8/3766/6
Should fix to set build distribution to trusty instead of xenial