### PR TITLE
Fix building docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM jruby:9.1-jdk
+FROM jruby:9.2-jdk
 
 RUN apt-get update -qq && apt-get install -y build-essential
 RUN echo 'gem: --no-rdoc --no-ri' >> /.gemrc

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 FROM jruby:9.2-jdk
 
-RUN apt-get update -qq && apt-get install -y build-essential
+RUN apt-get update -qq && apt-get install -y build-essential \
+  && apt-get clean && rm -rf /var/lib/apt/lists/*
 RUN echo 'gem: --no-rdoc --no-ri' >> /.gemrc
 
 ENV GEM_HOME /usr/local/bundle
@@ -13,15 +14,10 @@ RUN gem install bundler -v '< 2' \
 ENV BUNDLE_APP_CONFIG $GEM_HOME
 
 WORKDIR /app
-
-# these didn't work as ONBUILD, strangely. Idk why. -JBM
-COPY Gemfile ./
-COPY Gemfile.lock ./
-COPY Jarfile ./
-COPY Jarfile.lock ./
-RUN bundle install --system
-RUN jruby -S jbundle install
-COPY . .
-
 EXPOSE 9292
 CMD ["jruby", "-G", "-r", "jbundler", "-S", "rackup", "-o", "0.0.0.0", "config.ru"]
+
+# these didn't work as ONBUILD, strangely. Idk why. -JBM
+COPY Gemfile Gemfile.lock Jarfile Jarfile.lock ./
+RUN bundle install && jruby -S jbundle install
+COPY . .


### PR DESCRIPTION
I was trying to build the docker image but got an error. I noticed that the issues for the repository have been disabled, so just created a branch to fix the issue.

The issue is fixed after updating the base image to jruby 9.2. I also updated the Dockerfile to improve the image size and build cache (more here: faebadf).

## Original issue

1. What error message did you get?
    ```
    Sending build context to Docker daemon  101.7MB                                                                                                                
    Step 1/17 : FROM jruby:9.1-jdk                                                                                                                                 
     ---> 5a68c265dd1c                                                                                                                                             
    Step 2/17 : RUN apt-get update -qq && apt-get install -y build-essential                                                                                       
     ---> Using cache                                                                                                                                              
     ---> 515590e7c875                                                                                                                                             
    Step 3/17 : RUN echo 'gem: --no-rdoc --no-ri' >> /.gemrc                                                                                                       
     ---> Using cache                                                                                                                                              
     ---> fa670928db84                                                                                                                                             
    Step 4/17 : ENV GEM_HOME /usr/local/bundle                                                                                                                     
     ---> Using cache                                                                                                                                              
     ---> fd75d82804f5                                                                                                                                             
    Step 5/17 : ENV PATH $GEM_HOME/bin:$PATH                                                                                                                       
     ---> Using cache                                                                                                                                              
     ---> b9cf46e84009                                                                                                                                             
    Step 6/17 : RUN gem install bundler -v '< 2'   && bundle config --global path "$GEM_HOME"   && bundle config --global bin "$GEM_HOME/bin"                      
     ---> Using cache                                                                                                                                              
     ---> 2ab6665ceee9                                                                                                                                             
    Step 7/17 : ENV BUNDLE_APP_CONFIG $GEM_HOME                                                                                                                    
     ---> Using cache                                                                                                                                              
     ---> ef2730668958                                                                                                                                             
    Step 8/17 : WORKDIR /app                                                                                                                                       
     ---> Using cache                                                                                                                                              
     ---> ccf0a957db21                                                                                                                                             
    Step 9/17 : COPY Gemfile ./                                                                                                                                    
     ---> 82e144da6405                                                                                                                                             
    Step 10/17 : COPY Gemfile.lock ./                                                                                                                              
     ---> b4bc570e18b2                                                                                                                                                                                                                                                                                                             
    Step 11/17 : COPY Jarfile ./                                                                                                                                                                                                                                                                                                   
     ---> a4950a5ddd1e                                                                                                                                                                                                                                                                                                             
    Step 12/17 : COPY Jarfile.lock ./                                                                                                                              
     ---> 21ef450b654c                                                                                                                                             
    Step 13/17 : RUN bundle install                                                                                                                                
     ---> Running in 2c09cf7e41e2                                                                                                                                  
    Fetching gem metadata from https://rubygems.org/..........                                                                                                     
    Fetching gem metadata from https://rubygems.org/.                                                                                                              
    You have requested:                                                                                                                                            
      autoprefixer-rails = 9.8.6                                                                                                                                   
                                                                                                                                                                   
    The bundle currently has autoprefixer-rails locked at 9.8.6.3.                                                                                                 
    Try running `bundle update autoprefixer-rails`                                                                                                                 
                                                                                                                                                                   
    If you are updating multiple gems in your Gemfile at once,                                                                                                     
    try passing them all to `bundle update`                                     
    ```
2. What steps did you take?
    Clone and `docker build .`
3. What PDF were you trying to extract data from?
    N/A
4. What version of Tabula are you using?
   The master branch and it  also affects the 1.2.1 tag
5. What platform are you on?
   Linux