### PR TITLE
No more mixed content

### DIFF
--- a/index.html
+++ b/index.html
@@ -16,7 +16,7 @@
     <link rel="stylesheet" href="stylesheets/styles.css">
     <link rel="stylesheet" href="stylesheets/pygment_trac.css">
     <meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no">
-    <link rel="canonical" href="http://tabula.technology/" />
+    <link rel="canonical" href="https://tabula.technology/" />
     <!--[if lt IE 9]>
     <script src="//html5shiv.googlecode.com/svn/trunk/html5.js"></script>
     <![endif]-->
@@ -43,7 +43,7 @@
 
         <p><strong>Donate:</strong> Help support this project by <a href="https://opencollective.com/tabulapdf">backing us on OpenCollective</a>.</p>
 
-        <p>We'd love to hear from you! Say hi on Twitter at <a href="http://twitter.com/TabulaPDF">@TabulaPDF</a></p>
+        <p>We'd love to hear from you! Say hi on Twitter at <a href="https://twitter.com/TabulaPDF">@TabulaPDF</a></p>
       </header>
 
       <section aria-role="updates" style="border-bottom: 1px solid #999; margin-bottom: 1em; padding-bottom: 0">
@@ -66,7 +66,7 @@
         <h3>
           <a name="who-uses-tabula" class="anchor" href="#who-uses-tabula"><span class="octicon octicon-link"></span></a>Who Uses Tabula?
         </h3>
-        <p>Tabula is used to power investigative reporting at news organizations of all sizes, including <a href="http://projects.propublica.org/docdollars/">ProPublica</a>, <a href="http://www.thetimes.co.uk/tto/news/medianews/article4048545.ece">The Times of London</a>, <a href="http://blog.foreignpolicy.com/posts/2014/06/13/crs_report_details_us_expenses_on_iraq">Foreign Policy</a>, <a href="http://interactivos.lanacion.com.ar/mapa-elecciones-2013/">La Nación (Argentina)</a>, <a href="http://www.nytimes.com/interactive/2015/12/10/us/gun-sales-terrorism-obama-restrictions.html?_r=1">The New York Times</a> and the <a href="http://www.twincities.com/nation/ci_25247140/where-insurance-premiums-are-highest-new-health-laws">St. Paul (MN) Pioneer Press</a>.</p>
+        <p>Tabula is used to power investigative reporting at news organizations of all sizes, including <a href="https://projects.propublica.org/docdollars/">ProPublica</a>, <a href="http://www.thetimes.co.uk/tto/news/medianews/article4048545.ece">The Times of London</a>, <a href="http://blog.foreignpolicy.com/posts/2014/06/13/crs_report_details_us_expenses_on_iraq">Foreign Policy</a>, <a href="http://interactivos.lanacion.com.ar/mapa-elecciones-2013/">La Nación (Argentina)</a>, <a href="http://www.nytimes.com/interactive/2015/12/10/us/gun-sales-terrorism-obama-restrictions.html?_r=1">The New York Times</a> and the <a href="http://www.twincities.com/nation/ci_25247140/where-insurance-premiums-are-highest-new-health-laws">St. Paul (MN) Pioneer Press</a>.</p>
         <p>Grassroots organizations like <a href="http://www.schoolcuts.org/">SchoolCuts.org</a> rely on Tabula to turn clunky documents into human-friendly public resources.</p>
         <p>And researchers of all kinds use Tabula to turn PDF reports into Excel spreadsheets, CSVs, and JSON files for use in analysis and database applications.</p>
       </section>
@@ -82,7 +82,7 @@
             <li><b>Mac OS X:</b> <a onclick="var p = this.getAttribute('href').split('/'); ga('send', 'event', 'link', 'download', p[p.length - 1]);" href="https://github.com/tabulapdf/tabula/releases/download/v1.2.1/tabula-mac-1.2.1.zip">tabula-mac.zip</a></li>
             <li><b>Linux/Other:</b> <a onclick="var p = this.getAttribute('href').split('/'); ga('send', 'event', 'link', 'download', p[p.length - 1]);" href="https://github.com/tabulapdf/tabula/releases/download/v1.2.1/tabula-jar-1.2.1.zip">tabula-jar.zip</a>, view README.txt inside for instructions</li>
           </ul>
-          <li>Extract the zip file. (Instructions: <a href="http://windows.microsoft.com/en-us/windows-8/zip-unzip-files">Windows</a>, <a href="http://support.apple.com/kb/PH10915">Mac</a>)</li>
+          <li>Extract the zip file. (Instructions: <a href="https://windows.microsoft.com/en-us/windows-8/zip-unzip-files">Windows</a>, <a href="https://support.apple.com/kb/PH10915">Mac</a>)</li>
           <li>Go into the folder you just extracted. Run the "Tabula" program inside.</li>
           <li>A web browser will open. If it doesn't, open your web browser, and go to <a href="http://localhost:8080/">http://localhost:8080</a>. There's Tabula!</li>
         </ol>
@@ -95,7 +95,7 @@
           <li>Browse to the page you want, then select the table by clicking and dragging to draw a box around the table.</li>
           <li>Click "Preview &amp; Export Extracted Data". Tabula will try to extract the data and display a preview. Inspect the data to make sure it looks correct. If data is missing, you can go back to adjust your selection.</li>
           <li>Click the "Export" button.</li>
-          <li>Now you can work with your data as text file or a spreadsheet rather than a PDF! (You can open the downloaded file in Microsoft Excel or the free <a href="http://www.libreoffice.org/discover/calc/">LibreOffice Calc</a>)</p>
+          <li>Now you can work with your data as text file or a spreadsheet rather than a PDF! (You can open the downloaded file in Microsoft Excel or the free <a href="https://www.libreoffice.org/discover/calc/">LibreOffice Calc</a>)</p>
         </ol>
         <p>Note: Tabula only works on text-based PDFs, not scanned documents.</p>
       </section>
@@ -105,13 +105,13 @@
         <h3>
         <a name="authors-and-contributors" class="anchor" href="#authors-and-contributors"><span class="octicon octicon-link"></span></a>Authors and Contributors</h3>
 
-        <p>Tabula was created by <a href="http://jazzido.com/" target="_blank">Manuel Aristarán</a>, <a href="https://mike.tig.as/" target="_blank">Mike Tigas</a> and <a href="http://jeremybmerrill.com/" target="_blank">Jeremy B. Merrill</a> with the support of <a href="http://propublica.org">ProPublica</a>, <a href="http://blogs.lanacion.com.ar/data/">La Nación DATA</a>, <a href="http://opennews.org/">Knight-Mozilla OpenNews</a>, <a href="http://www.nytimes.com">The New York Times</a>. Tabula was designed by <a href="http://jasondas.com/">Jason Das</a>.</p>
+        <p>Tabula was created by <a href="http://jazzido.com/" target="_blank">Manuel Aristarán</a>, <a href="https://mike.tig.as/" target="_blank">Mike Tigas</a> and <a href="http://jeremybmerrill.com/" target="_blank">Jeremy B. Merrill</a> with the support of <a href="https://propublica.org">ProPublica</a>, <a href="https://blogs.lanacion.com.ar/data/">La Nación DATA</a>, <a href="https://opennews.org/">Knight-Mozilla OpenNews</a>, <a href="https://www.nytimes.com">The New York Times</a>. Tabula was designed by <a href="http://jasondas.com/">Jason Das</a>.</p>
 
         <p>Tabula was created by journalists for journalists and anyone else working with data locked away in PDFs. Tabula will always be free and open source.</p>
         <p>Want to contribute? <a href="https://github.com/tabulapdf/tabula">Fork it on GitHub</a> and check out the <a href="https://github.com/tabulapdf/tabula/blob/master/TODO.md"></a>to-do list</a> for ideas. You can also support our continued work on Tabula with <a href="https://opencollective.com/tabulapdf">a one-time or monthly donation</a>.</p>
-        <p>Tabula is made possible in part through <a href="https://opencollective.com/tabulapdf">the generosity of our users</a> and through grants from the <a href="http://www.knightfoundation.org/">Knight Foundation</a> and the <a href="https://shuttleworthfoundation.org/">Shuttleworth Foundation</a>.</p>
+        <p>Tabula is made possible in part through <a href="https://opencollective.com/tabulapdf">the generosity of our users</a> and through grants from the <a href="https://www.knightfoundation.org/">Knight Foundation</a> and the <a href="https://shuttleworthfoundation.org/">Shuttleworth Foundation</a>.</p>
         <p>
-          <a title="The John S. and James L. Knight Foundation" href="http://www.knightfoundation.org/" target="_blank"><img style="width:220px" alt="The John S. and James L. Knight Foundation" src="http://www.knightfoundation.org/media/uploads/media_images/knight-logo-300.jpg"></a>
+          <a title="The John S. and James L. Knight Foundation" href="http://www.knightfoundation.org/" target="_blank"><img style="width:220px" alt="The John S. and James L. Knight Foundation" src="https://www.knightfoundation.org/media/uploads/media_images/knight-logo-300.jpg"></a>
           &nbsp; <a title="The Shuttleworth Foundation" href="https://shuttleworthfoundation.org/" target="_blank"><img style="width:200px" alt="The Shuttleworth Foundation" src="shuttleworth.jpg"></a>
         </p>
       </section>


### PR DESCRIPTION
Replace HTTP links with HTTPS

This is most important for the image link (which is a 404 now anyways) to remove the mixed content warning.