### PR TITLE
Fix git clone documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ Tabula has bindings for JRuby and R. If you end up writing bindings for another 
    `rbenv`, ensure that JRuby is being used.
 
     ~~~
-    git clone git://github.com/tabulapdf/tabula.git
+    git clone https://github.com/tabulapdf/tabula.git
     cd tabula
 
     gem install bundler -v 1.17.3


### PR DESCRIPTION
`git://` protocol is no longer supported by github, using it results in this error
```
Cloning into 'tabula'...
fatal: remote error: 
  The unauthenticated git protocol on port 9418 is no longer supported.
Please see https://github.blog/2021-09-01-improving-git-protocol-security-github/ for more information.
```