### PR TITLE
Internal Server Error (500)

### DIFF
--- a/webapp/static/js/pdf_view.js
+++ b/webapp/static/js/pdf_view.js
@@ -62,9 +62,8 @@ Tabula.Selection = Backbone.Model.extend({
 
     var original_pdf_width = page.get('width');
     var original_pdf_height = page.get('height');
-    var pdf_rotation = page.get('rotation');
 
-    var scale = (Math.abs(pdf_rotation) == 90 ? original_pdf_height : original_pdf_width) / imageWidth;
+    var scale = original_pdf_width / imageWidth;
     var rp = this.attributes.getDims().relativePos;
     this.set({
       x1: rp.left * scale,
@@ -1139,7 +1138,6 @@ Tabula.PDFView = Backbone.View.extend(
       var page = Tabula.pdf_view.pdf_document.page_collection.findWhere({number: sel.page});
       var original_pdf_width = page.get('width');
       var original_pdf_height = page.get('height');
-      var pdf_rotation = page.get('rotation');
 
       // TODO: create selection models for pages that aren't lazyloaded, but obviously don't display them.
       if(Tabula.LazyLoad && !pageView){
@@ -1152,7 +1150,7 @@ Tabula.PDFView = Backbone.View.extend(
       if (!$img.length || $img.data('loaded') !== 'loaded' || !$img.height() ){ // if this page isn't shown currently or the image hasn't been rendered yet, then create a hidden selectionx
         return this.pdf_document.selections.createHiddenSelection(sel);
       }
-      var scale = image_width / (Math.abs(pdf_rotation) == 90 ? original_pdf_height : original_pdf_width);
+      var scale = image_width / original_pdf_width;
       var offset = $img.offset();
       var absolutePos = _.extend({}, offset,
                                 {


### PR DESCRIPTION
I tried to open Tabula in my work notebook and it showed the following Internal Server Error (500):

No such file or directory - NUL from org/jruby/RubyFile.java:366:in `initialize' from org/jruby/RubyIO.java:1154:in `open' from uri:classloader:/META-INF/jruby.home/lib/ruby/stdlib/rubygems/user_interaction.rb:681:in `initialize' from C:/Users/vitor/AppData/Local/Temp/jetty-0.0.0.0-8080-tabula.jar-_-any-6308546013162397813.dir/webapp/WEB-INF/gems/gems/bundler-1.16.1/lib/bundler/ui/rg_proxy.rb:11:in `initialize' from C:/Users/vitor/AppData/Local/Temp/jetty-0.0.0.0-8080-tabula.jar-_-any-6308546013162397813.dir/webapp/WEB-INF/gems/gems/bundler-1.16.1/lib/bundler.rb:74:in `ui=' from C:/Users/vitor/AppData/Local/Temp/jetty-0.0.0.0-8080-tabula.jar-_-any-6308546013162397813.dir/webapp/WEB-INF/gems/gems/bundler-1.16.1/lib/bundler.rb:70:in `ui' from C:/Users/vitor/AppData/Local/Temp/jetty-0.0.0.0-8080-tabula.jar-_-any-6308546013162397813.dir/webapp/WEB-INF/gems/gems/bundler-1.16.1/lib/bundler/definition.rb:252:in `resolve' from C:/Users/vitor/AppData/Local/Temp/jetty-0.0.0.0-8080-tabula.jar-_-any-6308546013162397813.dir/webapp/WEB-INF/gems/gems/bundler-1.16.1/lib/bundler/definition.rb:170:in `specs' from C:/Users/vitor/AppData/Local/Temp/jetty-0.0.0.0-8080-tabula.jar-_-any-6308546013162397813.dir/webapp/WEB-INF/gems/gems/bundler-1.16.1/lib/bundler/definition.rb:237:in `specs_for' from C:/Users/vitor/AppData/Local/Temp/jetty-0.0.0.0-8080-tabula.jar-_-any-6308546013162397813.dir/webapp/WEB-INF/gems/gems/bundler-1.16.1/lib/bundler/definition.rb:226:in `requested_specs' from C:/Users/vitor/AppData/Local/Temp/jetty-0.0.0.0-8080-tabula.jar-_-any-6308546013162397813.dir/webapp/WEB-INF/gems/gems/bundler-1.16.1/lib/bundler/runtime.rb:108:in `block in requested_specs' from C:/Users/vitor/AppData/Local/Temp/jetty-0.0.0.0-8080-tabula.jar-_-any-6308546013162397813.dir/webapp/WEB-INF/gems/gems/bundler-1.16.1/lib/bundler/runtime.rb:20:in `setup' from C:/Users/vitor/AppData/Local/Temp/jetty-0.0.0.0-8080-tabula.jar-_-any-6308546013162397813.dir/webapp/WEB-INF/gems/gems/bundler-1.16.1/lib/bundler.rb:107:in `setup' from C:/Users/vitor/AppData/Local/Temp/jetty-0.0.0.0-8080-tabula.jar-_-any-6308546013162397813.dir/webapp/WEB-INF/gems/gems/bundler-1.16.1/lib/bundler.rb:114:in `require' from C:\Users\vitor\AppData\Local\Temp\jetty-0.0.0.0-8080-tabula.jar-_-any-6308546013162397813.dir\webapp\WEB-INF\config.ru:4:in `block in (root)' from org/jruby/RubyBasicObject.java:1691:in `instance_eval' from C:/Users/vitor/AppData/Local/Temp/jetty-0.0.0.0-8080-tabula.jar-_-any-6308546013162397813.dir/webapp/WEB-INF/gems/gems/rack-2.0.4/lib/rack/builder.rb:55:in `initialize' from C:\Users\vitor\AppData\Local\Temp\jetty-0.0.0.0-8080-tabula.jar-_-any-6308546013162397813.dir\webapp\WEB-INF\config.ru:1:in `<main>'

How to fix that error?