### PR TITLE
Provide container images

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,21 @@
+on:
+  release:
+    types: [published]
+permissions:
+  contents: read
+  packages: write
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ github.token }}
+      - uses: docker/build-push-action@v4
+        with:
+          push: true
+          tags: |
+            ghcr.io/${{ github.repository }}:${{ github.ref_name }}
+            ghcr.io/${{ github.repository }}:latest

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM jruby:9.2-jdk
 
-RUN apt-get update -qq && apt-get install -y build-essential \
+RUN apt-get update -qq && apt-get install -y build-essential git \
   && apt-get clean && rm -rf /var/lib/apt/lists/*
 RUN echo 'gem: --no-rdoc --no-ri' >> /.gemrc
 


### PR DESCRIPTION
After merging this pull request and publishing a new release, this should work:

```
docker run --rm --publish 9292:9292 ghcr.io/tabulapdf/tabula
```

The service will be available on http://localhost:9292